### PR TITLE
Update to Lamb 0.59.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,29 @@
 - update docs
 - docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
-- update website:
-	- add histogram examples
-	- updated dependencies
-	- rename example objects keys and move `usage` to specific examples so that the reader will actually see usage changing eventually
-	- add colors to the UK examples
-	- create a list of entries from the examples instead of relying on Sapper scraping
-	- during the doc build we're now adding a `.nojekyll` file because of _layout.* files created by sapper that would otherwise be [ignored by Jekyll](https://help.github.com/en/enterprise/2.14/user/articles/files-that-start-with-an-underscore-are-missing)
-	- optimised exported routes weight
+- update to Lamb 0.59.2
+	- latest with correct `exports`: https://github.com/ascartabelli/lamb/releases/tag/v0.59.2
+	- renames: https://github.com/ascartabelli/lamb/releases/tag/v0.59.0
+		- `pick` -> `pickIn`
+		- `pickKeys` -> `pick`
+		- `pluckKey` -> `pluck`
+		- `renameKeys` -> `rename`
+		- `skipKeys` -> `skip`
+
+## website
+
+- add histogram examples
+- updated dependencies
+- rename example objects keys and move `usage` to specific examples so that the reader will actually see usage changing eventually
+- add colors to the UK examples
+- create a list of entries from the examples instead of relying on Sapper scraping
+- during the doc build we're now adding a `.nojekyll` file because of _layout.* files created by sapper that would otherwise be [ignored by Jekyll](https://help.github.com/en/enterprise/2.14/user/articles/files-that-start-with-an-underscore-are-missing)
+- optimised exported routes weight
+- Update to Lamb 0.59.2 (some renames needed)
+
+## `@svizzle/atlas` v0.2.1 (next)
+
+- Update to Lamb 0.59.2 (some renames needed)
 
 ## `@svizzle/barchart` v0.3.0 (next)
 
@@ -36,6 +51,7 @@
 			- `hoverColor`
 	- `barHeight` (was previously set in CSS)
 - temporarily removed the props doc from the README.md to avoid duplication with the website
+- Update to Lamb 0.59.2 (no renames needed)
 
 ## `@svizzle/choropleth` v0.3.0 (next)
 
@@ -61,12 +77,30 @@
 - docs:
 	- document only `ChoroplethG` with a mention of how to use `ChoroplethDiv` to reduce duplication
 	- add a specific route for `keyToColor`, it was used in toom many pages
+- Update to Lamb 0.59.2 (no renames needed)
+
+## `@svizzle/dev` v0.3.1 (next)
+
+- Update to Lamb 0.59.2 (no renames needed)
 
 ## `@svizzle/dom` v0.4.0 (next)
 
 - add `makeStyleVars`
 - docs: converted all examples to a REPL format
 - dev: using single quotes rather than double quote where possible
+- Update to Lamb 0.59.2 (some renames needed)
+
+## `@svizzle/file` v0.7.1 (next)
+
+- Update to Lamb 0.59.2 (some renames needed)
+
+## `@svizzle/geo` v0.5.1 (next)
+
+- Update to Lamb 0.59.2 (no renames needed)
+
+## `@svizzle/geometry` v0.2.1 (next)
+
+- Update to Lamb 0.59.2 (no renames needed)
 
 ## `@svizzle/histogram` v0.1.0 (new)
 
@@ -86,10 +120,15 @@
 	- add `getTrimmedBinsStats`
 	- add `isNonEmptyBin`
 
+## `@svizzle/request` v0.2.1 (next)
+
+- Update to Lamb 0.59.2 (no renames needed)
+
 ## `@svizzle/utils` v0.8.0 (next)
 
 - docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
+- Update to Lamb 0.59.2 (some renames needed)
 
 ### (Any -> Any):accumcb -> (Array -> Any)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2355,6 +2355,13 @@
 				"@svizzle/utils": "^0.4.0",
 				"d3-dsv": "^1.0.10",
 				"lamb": "^0.58.0"
+			},
+			"dependencies": {
+				"lamb": {
+					"version": "0.58.0",
+					"resolved": "https://registry.npmjs.org/lamb/-/lamb-0.58.0.tgz",
+					"integrity": "sha512-u0SZOM8/Tptt8ZDDmhdHmiH9yL+AmtZgkRcKv6r3vVljTm1BpOb4Xq5dW8OlA8QJpV2TQcJg6YKCsJ6t4u6BHA=="
+				}
 			}
 		},
 		"@svizzle/utils": {
@@ -2364,6 +2371,13 @@
 			"requires": {
 				"just-compare": "^1.3.0",
 				"lamb": "^0.58.0"
+			},
+			"dependencies": {
+				"lamb": {
+					"version": "0.58.0",
+					"resolved": "https://registry.npmjs.org/lamb/-/lamb-0.58.0.tgz",
+					"integrity": "sha512-u0SZOM8/Tptt8ZDDmhdHmiH9yL+AmtZgkRcKv6r3vVljTm1BpOb4Xq5dW8OlA8QJpV2TQcJg6YKCsJ6t4u6BHA=="
+				}
 			}
 		},
 		"@turf/bbox": {
@@ -7148,9 +7162,9 @@
 			}
 		},
 		"lamb": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/lamb/-/lamb-0.58.0.tgz",
-			"integrity": "sha512-u0SZOM8/Tptt8ZDDmhdHmiH9yL+AmtZgkRcKv6r3vVljTm1BpOb4Xq5dW8OlA8QJpV2TQcJg6YKCsJ6t4u6BHA=="
+			"version": "0.59.2",
+			"resolved": "https://registry.npmjs.org/lamb/-/lamb-0.59.2.tgz",
+			"integrity": "sha512-P4HBmG8q1VwBAKmmiw/gKl1m0cTqwL1sC8LCyaSIVCCbxhQe9IDSeKkFnL8eonPGDWsMgADvFqZzAImf28hExQ=="
 		},
 		"lerna": {
 			"version": "3.22.1",

--- a/packages/components/barchart/CHANGELOG.md
+++ b/packages/components/barchart/CHANGELOG.md
@@ -20,6 +20,7 @@
 			- `hoverColor`
 	- `barHeight` (was previously set in CSS)
 - temporarily removed the props doc from the README.md to avoid duplication with the website
+- Update to Lamb 0.59.2 (no renames needed)
 
 ## `@svizzle/barchart` v0.2.0
 

--- a/packages/components/barchart/package.json
+++ b/packages/components/barchart/package.json
@@ -7,7 +7,7 @@
 		"@svizzle/dom": "^0.3.0",
 		"@svizzle/utils": "^0.7.1",
 		"just-compare": "^1.3.0",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"yootils": "^0.0.16"
 	},
 	"description": "A vertical barchart component for Svelte.",

--- a/packages/components/barchart/rollup.config.js
+++ b/packages/components/barchart/rollup.config.js
@@ -26,6 +26,9 @@ const input = {
 	BarchartV: 'src/BarchartVDiv.svelte',
 	index: 'src/index.js',
 };
+const removeComments = cleanup({
+	extensions: ['js', 'mjs']
+});
 const treeshake = {
 	annotations: true,
 	moduleSideEffects: id =>
@@ -49,7 +52,7 @@ const cjsConfig = {
 		resolve(),
 		commonjs(),
 		svelte(),
-		cleanup(),
+		removeComments,
 	],
 	treeshake
 };
@@ -69,7 +72,7 @@ const makeConfig = _.pipe([
 			resolve(),
 			commonjs(),
 			svelte(),
-			cleanup(),
+			removeComments,
 			// json(),
 			// buble({
 			//	 transforms: { dangerousForOf: true }

--- a/packages/components/choropleth/CHANGELOG.md
+++ b/packages/components/choropleth/CHANGELOG.md
@@ -22,6 +22,7 @@
 - docs:
 	- document only `ChoroplethG` with a mention of how to use `ChoroplethDiv` to reduce duplication
 	- add a specific route for `keyToColor`, it was used in toom many pages
+- Update to Lamb 0.59.2 (no renames needed)
 
 ## `@svizzle/choropleth` v0.2.0
 

--- a/packages/components/choropleth/package.json
+++ b/packages/components/choropleth/package.json
@@ -9,7 +9,7 @@
 		"@svizzle/geo": "^0.5.0",
 		"@svizzle/utils": "^0.7.1",
 		"d3-geo": "^1.11.9",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"topojson-client": "^3.1.0"
 	},
 	"description": "A generic choropleth component for Svelte.",

--- a/packages/components/choropleth/rollup.config.js
+++ b/packages/components/choropleth/rollup.config.js
@@ -28,6 +28,9 @@ const input = {
 	ChoroplethG: 'src/ChoroplethG.svelte',
 	index: 'src/index.js',
 };
+const removeComments = cleanup({
+	extensions: ['js', 'mjs']
+});
 const treeshake = {
 	annotations: true,
 	moduleSideEffects: id =>
@@ -51,7 +54,7 @@ const cjsConfig = {
 		resolve(),
 		commonjs(),
 		svelte(),
-		cleanup(),
+		removeComments,
 		json(),
 	],
 	treeshake
@@ -72,8 +75,8 @@ const makeConfig = _.pipe([
 			resolve(),
 			commonjs(),
 			svelte(),
-			cleanup(),
 			json(),
+			removeComments,
 			// buble({
 			//	 transforms: { dangerousForOf: true }
 			// }),

--- a/packages/components/choropleth/src/ChoroplethG.svelte
+++ b/packages/components/choropleth/src/ChoroplethG.svelte
@@ -1,19 +1,19 @@
 <script>
-	import { createEventDispatcher } from 'svelte';
-	import { feature as geoObject } from 'topojson-client';
-	import { geoPath } from 'd3-geo';
-	import * as _ from 'lamb';
+	import {createEventDispatcher} from 'svelte';
+	import {feature as geoObject} from 'topojson-client';
+	import {geoPath} from 'd3-geo';
+	import {getPath} from 'lamb';
 	import {makeStyleVars} from '@svizzle/dom';
 	import {
 		makeUpdateFeaturesProperty,
 		setGeometryPrecision
 	} from '@svizzle/geo';
-	import { isNotNullWith } from '@svizzle/utils';
+	import {isNotNullWith} from '@svizzle/utils';
 
 	import * as projections from './projections';
 
 	const dispatch = createEventDispatcher();
-	const hasColor = isNotNullWith(_.getPath('properties.color'));
+	const hasColor = isNotNullWith(getPath('properties.color'));
 	const truncateGeojson = setGeometryPrecision(4);
 	const topoToGeo = (topojson, id) =>
 		truncateGeojson(geoObject(topojson, topojson.objects[id]));
@@ -58,12 +58,12 @@
 
 	// FIXME https://github.com/sveltejs/svelte/issues/4442
 	$: geojson = topoToGeo(topojson, topojsonId);
-	$: geometry = geometry ? _.merge(defaultGeometry, geometry) : defaultGeometry;
+	$: geometry = geometry ? {...defaultGeometry, ...geometry} : defaultGeometry;
 	$: isInteractive = isInteractive || false;
 	$: key_alt = key_alt || 'name';
 	$: projection = projection && projections[projection] || projections.geoEquirectangular;
 	$: selectedKeys = selectedKeys || [];
-	$: theme = theme ? _.merge(defaultTheme, theme) : defaultTheme;
+	$: theme = theme ? {...defaultTheme, ...theme} : defaultTheme;
 	$: style = makeStyleVars(theme);
 	$: innerHeight = Math.max(0, height - geometry.top - geometry.bottom);
 	$: innerWidth = Math.max(0, width - geometry.left - geometry.right);

--- a/packages/components/histogram/package.json
+++ b/packages/components/histogram/package.json
@@ -9,7 +9,7 @@
 		"@svizzle/geometry": "^0.2.0",
 		"@svizzle/utils": "^0.7.1",
 		"d3-scale": "^3.2.1",
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"description": "Svelte histogram component and histogram utilities.",
 	"devDependencies": {

--- a/packages/components/histogram/rollup.config.js
+++ b/packages/components/histogram/rollup.config.js
@@ -28,6 +28,9 @@ const input = {
 	HistogramG: 'src/HistogramG.svelte',
 	index: 'src/index.js',
 };
+const removeComments = cleanup({
+	extensions: ['js', 'mjs']
+});
 const treeshake = {
 	annotations: true,
 	moduleSideEffects: id =>
@@ -49,8 +52,8 @@ const cjsConfig = {
 		resolve(),
 		commonjs(),
 		svelte(),
-		cleanup(),
 		json(),
+		removeComments,
 	],
 	treeshake
 };
@@ -70,8 +73,8 @@ const makeConfig = _.pipe([
 			resolve(),
 			commonjs(),
 			svelte(),
-			cleanup(),
 			json(),
+			removeComments,
 			// buble({
 			//	 transforms: { dangerousForOf: true }
 			// }),

--- a/packages/docs/site/package-lock.json
+++ b/packages/docs/site/package-lock.json
@@ -1,0 +1,91 @@
+{
+	"name": "@svizzle/site",
+	"version": "0.2.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"esm": {
+			"version": "3.2.25",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+			"dev": true
+		},
+		"rollup": {
+			"version": "1.32.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+			"integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*",
+				"@types/node": "*",
+				"acorn": "^7.1.0"
+			},
+			"dependencies": {
+				"@types/estree": {
+					"version": "0.0.45",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
+					"integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
+					"dev": true
+				},
+				"@types/node": {
+					"version": "14.0.23",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
+					"integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
+					"dev": true
+				},
+				"acorn": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+					"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+					"dev": true
+				}
+			}
+		},
+		"rollup-plugin-svelte": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-5.2.3.tgz",
+			"integrity": "sha512-513vOht9A93OV7fvmpIq8mD1JFgTZ5LidmpULKM2Od9P1l8oI5KwvO32fwCnASuVJS1EkRfvCnS7vKQ8DF4srg==",
+			"dev": true,
+			"requires": {
+				"require-relative": "^0.8.7",
+				"rollup-pluginutils": "^2.8.2",
+				"sourcemap-codec": "^1.4.8"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+					"dev": true
+				},
+				"require-relative": {
+					"version": "0.8.7",
+					"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+					"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+					"dev": true
+				},
+				"rollup-pluginutils": {
+					"version": "2.8.2",
+					"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+					"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+					"dev": true,
+					"requires": {
+						"estree-walker": "^0.6.1"
+					}
+				},
+				"sourcemap-codec": {
+					"version": "1.4.8",
+					"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+					"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+					"dev": true
+				}
+			}
+		},
+		"svelte": {
+			"version": "3.24.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.24.0.tgz",
+			"integrity": "sha512-VFXom6EP2DK83kxy4ZlBbaZklSbZIrpNH3oNXlPYHJUuW4q1OuAr3ZoYbfIVTVYPDgrI7Yq0gQcOhDlAtO4qfw==",
+			"dev": true
+		}
+	}
+}

--- a/packages/docs/site/package.json
+++ b/packages/docs/site/package.json
@@ -8,6 +8,7 @@
 		"compression": "^1.7.1",
 		"d3-color": "^1.4.0",
 		"d3-scale": "^3.2.1",
+		"lamb": "^0.59.2",
 		"polka": "next",
 		"sirv": "^0.4.0",
 		"svelte-json-tree": "^0.1.0"
@@ -29,7 +30,6 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-svelte3": "^2.7.3",
 		"esm": "^3.2.25",
-		"lamb": "^0.58.0",
 		"npm-run-all": "^4.1.5",
 		"rollup": "^2.21.0",
 		"rollup-plugin-babel": "^4.4.0",

--- a/packages/docs/site/src/bin/makeEntries.js
+++ b/packages/docs/site/src/bin/makeEntries.js
@@ -7,7 +7,7 @@ import * as examples from '../routes/components/_examples';
 
 const makeEntries = _.pipe([
 	concatValues,
-	_.pluckKey('slug'),
+	_.pluck('slug'),
 	_.mapWith(prepend('components/')),
 	joinWith(' ')
 ]);

--- a/packages/docs/site/src/routes/components/_examples/barchart.js
+++ b/packages/docs/site/src/routes/components/_examples/barchart.js
@@ -181,7 +181,7 @@ const examples = [
 				<BarchartV
 					{items}
 					{keyToColor}
-					theme={barDefaultColor:'${barDefaultColor}'}
+					theme={{barDefaultColor:'${barDefaultColor}'}}
 				/>
 			`,
 		}, {
@@ -195,7 +195,7 @@ const examples = [
 				<BarchartV
 					{items}
 					{keyToColor}
-					theme={barDefaultColor:'${barDefaultColor}'}
+					theme={{barDefaultColor:'${barDefaultColor}'}}
 				/>
 			`,
 		}, {
@@ -209,7 +209,7 @@ const examples = [
 				<BarchartV
 					{items}
 					{keyToColor}
-					theme={barDefaultColor:'${barDefaultColor}'}
+					theme={{barDefaultColor:'${barDefaultColor}'}}
 				/>
 			`,
 		}],

--- a/packages/docs/site/src/routes/components/_examples/props.js
+++ b/packages/docs/site/src/routes/components/_examples/props.js
@@ -315,7 +315,7 @@ const keyToColorWorldFull = {
 }
 
 // keep these 2 commented for the `keyToColorWorld` example to show 2 black bars.
-export const keyToColorWorld = _.skip(keyToColorWorldFull, ['AL', 'AD']);
+export const keyToColorWorld = _.skipIn(keyToColorWorldFull, ['AL', 'AD']);
 
 export const keyToColorWorldShort = {
 	AM: 'blue',

--- a/packages/tools/atlas/CHANGELOG.md
+++ b/packages/tools/atlas/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `@svizzle/atlas` v0.2.1 (next)
+
+- Update to Lamb 0.59.2 (some renames needed)
+
 ## `@svizzle/atlas` v0.2.0
 
 - fixed the scripts to extract NUTS topojson by country (#48)

--- a/packages/tools/atlas/bin/01_eurostat_nuts.js
+++ b/packages/tools/atlas/bin/01_eurostat_nuts.js
@@ -57,7 +57,7 @@ const permute = _.pipe([
 ]);
 
 const makeTopojsonUpdater = key => transformValues({
-	objects: _.renameKeys({[key]: 'NUTS'}),
+	objects: _.rename({[key]: 'NUTS'}),
 });
 
 /*

--- a/packages/tools/atlas/package.json
+++ b/packages/tools/atlas/package.json
@@ -14,7 +14,7 @@
 		"eslint-plugin-import": "^2.18.2",
 		"esm": "^3.2.25",
 		"js-yaml": "^3.13.1",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"mkdirp": "^0.5.1",
 		"node-fetch": "^2.6.0",
 		"rimraf": "^3.0.0",
@@ -41,7 +41,7 @@
 	"license": "MIT",
 	"name": "@svizzle/atlas",
 	"peerDependencies": {
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/tools/dev/CHANGELOG.md
+++ b/packages/tools/dev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `@svizzle/dev` v0.3.1 (next)
+
+- Update to Lamb 0.59.2 (no renames needed)
+
 ## `@svizzle/dev` (next)
 
 - docs: converted all examples to a REPL-like format

--- a/packages/tools/dev/package.json
+++ b/packages/tools/dev/package.json
@@ -7,7 +7,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-import": "^2.18.2",
 		"esm": "^3.2.25",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"mkdirp": "^0.5.1",
 		"mocha": "^5.2.0",
 		"rimraf": "^3.0.0",
@@ -39,7 +39,7 @@
 	"module": "index.js",
 	"name": "@svizzle/dev",
 	"peerDependencies": {
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/tools/dom/CHANGELOG.md
+++ b/packages/tools/dom/CHANGELOG.md
@@ -3,6 +3,7 @@
 - add `makeStyleVars`
 - docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
+- Update to Lamb 0.59.2 (some renames needed)
 
 ## `@svizzle/dom` v0.3.0
 

--- a/packages/tools/dom/package.json
+++ b/packages/tools/dom/package.json
@@ -15,7 +15,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-import": "^2.18.2",
 		"esm": "^3.2.25",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"mkdirp": "^0.5.1",
 		"mocha": "^5.2.0",
 		"rimraf": "^3.0.0",
@@ -45,7 +45,7 @@
 	"module": "index.js",
 	"name": "@svizzle/dom",
 	"peerDependencies": {
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/tools/dom/src/nodes.js
+++ b/packages/tools/dom/src/nodes.js
@@ -3,7 +3,7 @@
 */
 
 import {select} from 'd3-selection';
-import {pick} from 'lamb';
+import {pickIn} from 'lamb';
 import {mapValuesToFloatPossibly} from '@svizzle/utils';
 
 /* get */
@@ -30,7 +30,7 @@ getElementGeometry(node, ['fontSize'])
  */
 export const getElementGeometry = (elem, additionalProps = []) =>
 	mapValuesToFloatPossibly(
-		pick(getComputedStyle(elem), [
+		pickIn(getComputedStyle(elem), [
 			'width',
 			'height',
 			...additionalProps

--- a/packages/tools/file/CHANGELOG.md
+++ b/packages/tools/file/CHANGELOG.md
@@ -1,7 +1,8 @@
-## `@svizzle/file` (next)
+## `@svizzle/file` v0.7.1 (next)
 
 - docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
+- Update to Lamb 0.59.2 (some renames needed)
 
 ## `@svizzle/file` v0.7.0
 

--- a/packages/tools/file/package.json
+++ b/packages/tools/file/package.json
@@ -14,7 +14,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-import": "^2.18.2",
 		"esm": "^3.2.25",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"mkdirp": "^0.5.1",
 		"mocha": "^5.2.0",
 		"nock": "^10.0.6",
@@ -51,7 +51,7 @@
 	"module": "index.js",
 	"name": "@svizzle/file",
 	"peerDependencies": {
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/tools/file/src/path.js
+++ b/packages/tools/file/src/path.js
@@ -67,7 +67,7 @@ export const filterJsonExtensions =
  */
 export const renameToExtension = ext => _.pipe([
 	path.parse,
-	_.skipKeys(['base']), // [1]
+	_.skip(['base']), // [1]
 	mergeObj({ext}),
 	path.format
 ]);

--- a/packages/tools/geo/CHANGELOG.md
+++ b/packages/tools/geo/CHANGELOG.md
@@ -1,7 +1,9 @@
-## `@svizzle/geo` (next)
+
+## `@svizzle/geo` v0.5.1 (next)
 
 - docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
+- Update to Lamb 0.59.2 (no renames needed)
 
 ## `@svizzle/geo` v0.5.0
 

--- a/packages/tools/geo/package.json
+++ b/packages/tools/geo/package.json
@@ -19,7 +19,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-import": "^2.18.2",
 		"esm": "^3.2.25",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"mkdirp": "^0.5.1",
 		"mocha": "^5.2.0",
 		"rimraf": "^3.0.0",
@@ -50,7 +50,7 @@
 	"module": "index.js",
 	"name": "@svizzle/geo",
 	"peerDependencies": {
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/tools/geometry/CHANGELOG.md
+++ b/packages/tools/geometry/CHANGELOG.md
@@ -1,7 +1,8 @@
-## `@svizzle/geometry` (next)
+## `@svizzle/geometry` v0.2.1 (next)
 
 - docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
+- Update to Lamb 0.59.2 (no renames needed)
 
 ## `@svizzle/geometry` v0.2.0
 

--- a/packages/tools/geometry/package.json
+++ b/packages/tools/geometry/package.json
@@ -10,7 +10,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-import": "^2.18.2",
 		"esm": "^3.2.25",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"mkdirp": "^0.5.1",
 		"mocha": "^5.2.0",
 		"rimraf": "^3.0.0",
@@ -41,7 +41,7 @@
 	"module": "index.js",
 	"name": "@svizzle/geometry",
 	"peerDependencies": {
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/tools/request/CHANGELOG.md
+++ b/packages/tools/request/CHANGELOG.md
@@ -1,8 +1,8 @@
-## `@svizzle/request` (next)
+## `@svizzle/request` v0.2.1 (next)
 
 - dev: using single quotes rather than double quote where possible
-
 - dev: using single quotes rather than double quote where possible
+- Update to Lamb 0.59.2 (no renames needed)
 
 ## `@svizzle/request` v0.2.0
 

--- a/packages/tools/request/package.json
+++ b/packages/tools/request/package.json
@@ -15,7 +15,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-import": "^2.18.2",
 		"esm": "^3.2.25",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"mkdirp": "^0.5.1",
 		"mocha": "^5.2.0",
 		"nock": "^10.0.6",
@@ -48,7 +48,7 @@
 	"module": "index.js",
 	"name": "@svizzle/request",
 	"peerDependencies": {
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/tools/utils/CHANGELOG.md
+++ b/packages/tools/utils/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
+- Update to Lamb 0.59.2 (some renames needed)
 
 ### (Any -> Any):accumcb -> (Array -> Any)
 

--- a/packages/tools/utils/package.json
+++ b/packages/tools/utils/package.json
@@ -11,7 +11,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-import": "^2.18.2",
 		"esm": "^3.2.25",
-		"lamb": "^0.58.0",
+		"lamb": "^0.59.2",
 		"mkdirp": "^0.5.1",
 		"mocha": "^5.2.0",
 		"rimraf": "^3.0.0",
@@ -44,7 +44,7 @@
 	"module": "index.js",
 	"name": "@svizzle/utils",
 	"peerDependencies": {
-		"lamb": "^0.58.0"
+		"lamb": "^0.59.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/tools/utils/src/array-[array-array].js
+++ b/packages/tools/utils/src/array-[array-array].js
@@ -47,7 +47,7 @@ export const makeArrayTransformer = fnArr => _.pipe([
  * @version 0.8.0
  * @see https://ascartabelli.github.io/lamb/module-lamb.html#pluckKey
  */
-export const pluckKeys = keys => _.mapWith(_.pickKeys(keys));
+export const pluckKeys = keys => _.mapWith(_.pick(keys));
 
 /**
  * Return a function expecting an array and removing items at the provided indices

--- a/packages/tools/utils/src/array-[object-array].js
+++ b/packages/tools/utils/src/array-[object-array].js
@@ -51,7 +51,7 @@ export const makeKeysGetter = _.pipe([
  */
 export const pickAndConcatValues =
 	keys => _.pipe([
-		_.pickKeys(keys),
+		_.pick(keys),
 		_.values,
 		_.apply(concat)
 	]);

--- a/packages/tools/utils/src/array-[object-object].js
+++ b/packages/tools/utils/src/array-[object-object].js
@@ -155,6 +155,6 @@ export const applyTransformsSequence = pathFnPairs => obj =>
 }
  *
  * @version 0.8.0
- * @see https://ascartabelli.github.io/lamb/module-lamb.html#pluckKey
+ * @see https://ascartabelli.github.io/lamb/module-lamb.html#pluck
  */
-export const pluckValuesKeys = keys => _.mapValuesWith(_.pickKeys(keys));
+export const pluckValuesKeys = keys => _.mapValuesWith(_.pick(keys));

--- a/packages/tools/utils/src/array-[object-object].md
+++ b/packages/tools/utils/src/array-[object-object].md
@@ -1,4 +1,4 @@
 # lamb
 
-- pickKeys
-- skipKeys
+- pick
+- skip

--- a/packages/tools/utils/src/object-[object-object].md
+++ b/packages/tools/utils/src/object-[object-object].md
@@ -1,3 +1,3 @@
 # lamb
 
-- renameKeys
+- rename

--- a/packages/tools/utils/src/string-[iterable-array].md
+++ b/packages/tools/utils/src/string-[iterable-array].md
@@ -1,3 +1,3 @@
 # lamb
 
-- pluckKey
+- pluck


### PR DESCRIPTION
`pick` -> `pickIn`
`pickKeys` -> `pick`
`pluckKey` -> `pluck`
`renameKeys` -> `rename`
`skipKeys` -> `skip`

renames: https://github.com/ascartabelli/lamb/releases/tag/v0.59.0
version with correct `exports`: https://github.com/ascartabelli/lamb/releases/tag/v0.59.2

Closes #93

Also:
- /choropleth: upgrade @rollup/plugin-json ^4.0.2 -> ^4.1.0