### PR TITLE
/utils: end of line functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,12 @@
 
 ## `@svizzle/utils` v0.8.0 (next)
 
-- docs: converted all examples to a REPL format
+- docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
+
+### (Any -> Any):accumcb -> (Array -> Any)
+
+- add tests to make sure `reduceFromArr` and `reduceFromObj` return a new instance of the initial value every time they get called
 
 ### (String -> String) -> (Object -> Object)
 
@@ -118,10 +122,17 @@
 ### Object -> Boolean
 
 - add `hasSomeNullValues`
+- add tests to `endsWithNewLine` to check Windows line ending
+
+### String -> Number
+
+- add `getEndOfLineLength`
 
 ### String -> String
 
 - add `capitalize`
+- make `trimLastNewline` compatible with Windows line ending
+
 
 ## 20200411_2
 

--- a/packages/tools/utils/CHANGELOG.md
+++ b/packages/tools/utils/CHANGELOG.md
@@ -3,6 +3,10 @@
 - docs: converted all examples to a REPL-like format
 - dev: using single quotes rather than double quote where possible
 
+### (Any -> Any):accumcb -> (Array -> Any)
+
+- add tests to make sure `reduceFromArr` and `reduceFromObj` return a new instance of the initial value every time they get called
+
 ### (String -> String) -> (Object -> Object)
 
 - add `renameKeysWith`
@@ -30,10 +34,17 @@
 ### Object -> Boolean
 
 - add `hasSomeNullValues`
+- add tests to `endsWithNewLine` to check Windows line ending
+
+### String -> Number
+
+- add `getEndOfLineLength`
 
 ### String -> String
 
 - add `capitalize`
+- make `trimLastNewline` compatible with Windows line ending
+
 
 ## `@svizzle/utils` v0.7.1
 

--- a/packages/tools/utils/src/[any-any]:accumcb-[array-any].spec.js
+++ b/packages/tools/utils/src/[any-any]:accumcb-[array-any].spec.js
@@ -22,6 +22,20 @@ describe('(Any -> Any):accumcb -> (Array -> Any)', function() {
 				[0, 4, 7]
 			);
 		});
+		it('should create a different initial array each time it gets called', function() {
+			const reduce1 = reduceFromEmptyArray((acc, x) => {
+				acc.push(x.value);
+				return acc;
+			});
+			const reduce2 = reduceFromEmptyArray((acc, x) => {
+				acc.push(x.value);
+				return acc;
+			});
+			reduce1([{value: 1}, {value: 2}]);
+			const b = reduce2([{value: 3}, {value: 4}]);
+
+			assert.notStrictEqual(b, [1, 2, 3, 4]);
+		});
 	});
 	describe('reduceFromEmptyObject', function() {
 		it('should return a reduce function expecting an array to reduce with the passed reducer with an empty object as the initial value', function() {
@@ -34,7 +48,28 @@ describe('(Any -> Any):accumcb -> (Array -> Any)', function() {
 					{id: '00', name: 'a'},
 					{id: '11', name: 'b'}
 				]),
-				{ '11': 'b', '00': 'a' }
+				{'11': 'b', '00': 'a'}
+			);
+		});
+		it('should create a different initial object each time it gets called', function() {
+			const reduce1 = reduceFromEmptyObject((acc, x) => {
+				acc[x.id] = x.name;
+				return acc;
+			});
+			const reduce2 = reduceFromEmptyObject((acc, x) => {
+				acc[x.id] = x.name;
+				return acc;
+			});
+			reduce1([
+				{id: 'a', name: 'a'},
+				{id: 'b', name: 'b'}
+			]);
+			const b = reduce2([
+				{id: 'b', name: 'c'},
+			]);
+			assert.notStrictEqual(
+				b,
+				{'c': 'c', 'b': 'b', 'a': 'a'}
 			);
 		});
 	});

--- a/packages/tools/utils/src/any-any.js
+++ b/packages/tools/utils/src/any-any.js
@@ -14,20 +14,18 @@ import {isValidNumber} from "./any-boolean";
  * @return {(*|array)}
  *
  * @example
- * undefined => []
- * [1, 2, 3] => [1, 2, 3]
- * {a: 1} => {a: 1}
- * "a" => "a"
+> makeEmptyArrayIfUndefined(undefined)
+[]
+> makeEmptyArrayIfUndefined([1, 2, 3])
+[1, 2, 3]
+> makeEmptyArrayIfUndefined({a: 1})
+{a: 1}
+> makeEmptyArrayIfUndefined('a')
+'a'
  *
  * @version 0.1.0
  */
 export const makeEmptyArrayIfUndefined = x => _.isUndefined(x) ? [] : x;
-
-// export const makeEmptyArrayIfUndefined = _.condition(
-//     _.isUndefined,
-//     _.always([]),
-//     _.identity
-// );
 
 /**
  * Return a number if the input can be converted to float, identity otherwise

--- a/packages/tools/utils/src/any-any.spec.js
+++ b/packages/tools/utils/src/any-any.spec.js
@@ -45,6 +45,11 @@ describe('Any -> Any', function() {
 				assert.deepStrictEqual(makeEmptyArrayIfUndefined({a: 1}), {a: 1});
 				assert.deepStrictEqual(makeEmptyArrayIfUndefined('str'), 'str');
 			});
+			it('should create different objects each time it gets called', function() {
+				const a = makeEmptyArrayIfUndefined(undefined);
+				const b = makeEmptyArrayIfUndefined(undefined);
+				assert.notStrictEqual(a, b);
+			});
 		});
 	});
 });

--- a/packages/tools/utils/src/string-boolean.js
+++ b/packages/tools/utils/src/string-boolean.js
@@ -20,10 +20,12 @@ import {makeEndsWith} from './string-[string-boolean]';
 false
 > endsWithNewLine('abc\n')
 true
+> endsWithNewLine('abc\r\n')
+true
  *
  * @version 0.5.0
  */
-export const endsWithNewLine = makeEndsWith('\n');
+export const endsWithNewLine = makeEndsWith('\n'); // s => (/\r?\n/).test(s);
 
 /**
  * Return true if the trimmed string is not empty

--- a/packages/tools/utils/src/string-boolean.spec.js
+++ b/packages/tools/utils/src/string-boolean.spec.js
@@ -4,9 +4,14 @@ import {endsWithNewLine, isTrimmedNotEmpty} from './string-boolean';
 
 describe('String -> Boolean', function() {
 	describe('endsWithNewLine', function() {
-		it('should return true if the string ends with a newline', function() {
-			assert.deepStrictEqual(endsWithNewLine('abc'), false);
+		it('should return true if the string ends with a newline (Unix)', function() {
 			assert.deepStrictEqual(endsWithNewLine('abc\n'), true);
+		});
+		it('should return true if the string ends with a newline (Windows)', function() {
+			assert.deepStrictEqual(endsWithNewLine('abc\r\n'), true);
+		});
+		it('should return false if the string does not end with a newline', function() {
+			assert.deepStrictEqual(endsWithNewLine('abc'), false);
 		});
 	});
 	describe('isTrimmedNotEmpty', function() {

--- a/packages/tools/utils/src/string-number.js
+++ b/packages/tools/utils/src/string-number.js
@@ -1,0 +1,23 @@
+/**
+* @module @svizzle/utils/string-number
+*/
+
+/**
+ * Return the length of the end of line, if any.
+ *
+ * @function
+ * @arg {string}
+ * @return {number}
+ *
+ * @example
+> getEndOfLineLength('hello')
+0
+> getEndOfLineLength('hello\n')
+1
+> getEndOfLineLength('hello\r\n')
+2
+ *
+ * @version 0.8.0
+ */
+export const getEndOfLineLength = s =>
+	(/\r\n$/u).test(s) ? 2 : (/\n$/u).test(s) ? 1 : 0;

--- a/packages/tools/utils/src/string-number.spec.js
+++ b/packages/tools/utils/src/string-number.spec.js
@@ -1,0 +1,17 @@
+import {strict as assert} from 'assert';
+
+import {getEndOfLineLength} from './string-number';
+
+describe('String -> Number', function() {
+	describe('getEndOfLineLength', function() {
+		it('should return 0 if the input string has no end of line', function() {
+			assert.deepStrictEqual(getEndOfLineLength('hello'), 0);
+		});
+		it('should return 1 if the input string has the Unix end of line', function() {
+			assert.deepStrictEqual(getEndOfLineLength('hello\n'), 1);
+		});
+		it('should return 1 if the input string has the Windows end of line', function() {
+			assert.deepStrictEqual(getEndOfLineLength('hello\r\n'), 2);
+		});
+	});
+});

--- a/packages/tools/utils/src/string-string.js
+++ b/packages/tools/utils/src/string-string.js
@@ -4,8 +4,9 @@
 
 import * as _ from 'lamb';
 
-import {sliceStringAt} from './array-[string-string]';
+import {sliceString} from './string_proto-string';
 import {endsWithNewLine} from './string-boolean';
+import {getEndOfLineLength} from './string-number';
 
 /**
  * Capitalise the input string
@@ -30,10 +31,22 @@ export const capitalize = s => s.charAt(0).toUpperCase() + s.slice(1);
  * @return {array}
  *
  * @example
- * trimLastNewline('a\nb\nc') // 'a\nb\nc'
- * trimLastNewline('a\nb\nc\n') // 'a\nb\nc'
- * trimLastNewline('a\nb\nc\n\n') // 'a\nb\nc\n'
+> trimLastNewline('a\nb\nc')
+'a\nb\nc'
+> trimLastNewline('a\nb\nc\n')
+'a\nb\nc'
+> trimLastNewline('a\nb\nc\n\n')
+'a\nb\nc\n'
+> trimLastNewline('a\nb\nc\r\n')
+'a\nb\nc'
+> trimLastNewline('a\nb\nc\n\r\n')
+'a\nb\nc\n'
  *
  * @version 0.5.0
  */
-export const trimLastNewline = _.when(endsWithNewLine, sliceStringAt([0, -1]));
+export const trimLastNewline =
+	_.when(endsWithNewLine, s => {
+		const L = getEndOfLineLength(s);
+
+		return sliceString(s, 0, -L);
+	});

--- a/packages/tools/utils/src/string-string.spec.js
+++ b/packages/tools/utils/src/string-string.spec.js
@@ -12,11 +12,17 @@ describe('String -> String', function() {
 		it('should not trim the last char if it\'s not a newline', function() {
 			assert.deepStrictEqual(trimLastNewline('a\nb\nc'), 'a\nb\nc');
 		});
-		it('should trim the last char if it\'s a newline', function() {
+		it('should trim the last char if it\'s a newline char (Unix)', function() {
 			assert.deepStrictEqual(trimLastNewline('a\nb\nc\n'), 'a\nb\nc');
 		});
-		it('should just one newline at the end of the string', function() {
+		it('should trim just one newline char at the end of the string (Unix)', function() {
 			assert.deepStrictEqual(trimLastNewline('a\nb\nc\n\n'), 'a\nb\nc\n');
+		});
+		it('should trim the last two chars if it has a Windows newline', function() {
+			assert.deepStrictEqual(trimLastNewline('a\nb\nc\r\n'), 'a\nb\nc');
+		});
+		it('should trim just the last two chars if it has a Windows newline', function() {
+			assert.deepStrictEqual(trimLastNewline('a\nb\nc\n\r\n'), 'a\nb\nc\n');
 		});
 	});
 });


### PR DESCRIPTION
- add `getEndOfLineLength`
- make `trimLastNewline` compatible with Windows line ending
- add tests to `endsWithNewLine` to check Windows line ending

Closes #86

Also:
- add tests to make sure `reduceFromArr` and `reduceFromObj` return a new instance of the initial value every time they get called
- turn some more examples in REPL-like format