### PR TITLE
/barchart: `ref.format`, `ref.keyAbbr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Svizzle changelog
 
+## next
+
+## `@svizzle/barchart` v0.6.3
+
+When we build the ref label we now can:
+- format the value using the `format` property of a reference
+- abbreviate the key in case the label goes off the barchart width, using the `keyAbbr` property of a reference
+
 ## 20200911
 
 ## `@svizzle/barchart` v0.6.2

--- a/packages/components/barchart/CHANGELOG.md
+++ b/packages/components/barchart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## `@svizzle/barchart` v0.6.3
+
+When we build the ref label we now can:
+- format the value using the `format` property of a reference
+- abbreviate the key in case the label goes off the barchart width, using the `keyAbbr` property of a reference
+
 ## `@svizzle/barchart` v0.6.2
 
 - fix: calculate refs labels length using the whole label text

--- a/packages/components/barchart/src/BarchartVDiv.svelte
+++ b/packages/components/barchart/src/BarchartVDiv.svelte
@@ -143,28 +143,38 @@
 
 	$: makeRefsLayout = pipe([
 		sortByValue,
-		mapWith((obj, idx) => {
-			const label = `${obj.key} (${obj.value})`;
-			const textLength = label.length * theme.fontSize * 0.6;
-			const rectWidth = textLength + 2 * theme.padding;
-			const valueX = getX(obj.value);
-			const isRight = valueX + rectWidth > width;
+		mapWith((ref, idx) => {
+			const valueX = getX(ref.value);
+			let formattedValue = ref.formatFn ? ref.formatFn(ref.value) : ref.value;
+			let label = `${ref.key} (${formattedValue})`;
+			let textLength = label.length * theme.fontSize * 0.5;
+			let rectWidth = textLength + 2 * theme.padding;
+			let goesOff = valueX + rectWidth > width;
+			let isAlignedRight = goesOff && valueX > width / 2;
+
+			if (goesOff && ref.keyAbbr) {
+				label = `${ref.keyAbbr} (${formattedValue})`;
+				textLength = label.length * theme.fontSize * 0.5;
+				rectWidth = textLength + 2 * theme.padding;
+				isAlignedRight =
+					valueX + rectWidth > width
+					&& valueX > width / 2;
+			}
 
 			return {
-				...obj,
-				isRight,
+				...ref,
+				isAlignedRight,
 				label,
 				rectWidth,
 				textLength,
-				textX: isRight ? -theme.padding : theme.padding,
+				textX: isAlignedRight ? -theme.padding : theme.padding,
 				valueX,
-				x: isRight ? -rectWidth : 0,
+				x: isAlignedRight ? -rectWidth : 0,
 				y: theme.padding + idx * (theme.padding + refHeight)
 			}
 		})
 	]);
 	$: refsLayout = refs && refs.length && makeRefsLayout(refs);
-
 	$: refHeight = theme.padding + theme.fontSize;
 	$: refsHeight =
 		refs && refs.length * (theme.padding + refHeight) + theme.padding
@@ -253,7 +263,7 @@
 				{#each refsLayout as {
 					color,
 					dasharray,
-					isRight,
+					isAlignedRight,
 					label,
 					linewidth,
 					rectWidth,
@@ -273,7 +283,7 @@
 						height={refHeight}
 					/>
 					<text
-						class:right={isRight}
+						class:right={isAlignedRight}
 						x={textX}
 						y={refHeight / 2}
 						{textLength}


### PR DESCRIPTION
When when we build the ref label we now can:
- format the value
- abbreviate the key in case the label goes off the barchart width

Closes #142