### PR TITLE
/legend: add a flag to `ColorBinsG` to show only the ticks extent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Svizzle changelog
 
+## next
+
+## `@svizzle/histogram` v0.4.0
+
+- utils: add `getBinsTicksExtent`
+
+## `@svizzle/legend` v0.2.0
+
+- add the field `showTicksExtentOnly` to `flags` prop
+
+## `@svizzle/site` v0.3.4
+
+- `legend/ColorsBinG`:
+	- document `flags.showTicksExtentOnly`
+	- document the `geometry` prop
+
+
 ## 20210415
 
 ## `@svizzle/time_region_value` v0.1.1

--- a/packages/components/histogram/CHANGELOG.md
+++ b/packages/components/histogram/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `@svizzle/histogram` v0.4.0 (next)
+
+- utils: add `getBinsTicksExtent`
+
 ## `@svizzle/histogram` v0.3.1
 
 - updated some dev dependencies:

--- a/packages/components/histogram/README.md
+++ b/packages/components/histogram/README.md
@@ -6,4 +6,4 @@ The `HistogramG` component can be used within an SVG element (its main element b
 
 The `HistogramDiv` component can be used within an HTML element (its main element being a `div`) and has the same props of `HistogramG` excluding `width` and `height` and with the addition of `headerHeight`, `padding` and `title`.
 
-Utilities can be useful when binning data.
+[Utilities](packages/components/histogram/src/utils.js) can be useful when binning data.

--- a/packages/components/histogram/src/utils.js
+++ b/packages/components/histogram/src/utils.js
@@ -3,10 +3,11 @@
 */
 
 import * as _ from 'lamb';
-import { extent, pairs } from 'd3-array';
+import {extent, pairs} from 'd3-array';
 import {
 	arrayMaxWith,
 	arrayMinWith,
+	getFirstAndLast,
 	getValues,
 	inclusiveRange,
 	isIterableNotEmpty,
@@ -79,7 +80,7 @@ export const exactAmountBins = ({
 	const integerMax = integerMin + step * amount;
 	const ranges = pairs(inclusiveRange([integerMin, integerMax, step]));
 
-	// TODO svizzle
+	// TODO svizzle/utils
 	const findRangeIndex = _.adapter(
 		_.map(ranges, (range, index) => {
 			const predicate = _.pipe([
@@ -119,18 +120,21 @@ export const exactAmountBins = ({
  * @example
 > areValidBins([])
 false
+
 > areValidBins([
 	{values: [{a: 2}, {a: 6}]},
 	{range: [6, 10], values: [{a: 7}, {a: 8}]},
 	{range: [10, 14], values: [{a: 12}, {a: 14}]}
 ])
 false
+
 > areValidBins([
 	{range: null, values: [{a: 2}, {a: 6}]},
 	{range: [6, 10], values: [{a: 7}, {a: 8}]},
 	{range: [10, 14], values: [{a: 12}, {a: 14}]}
 ])
 false
+
 > areValidBins([
 	{range: [2, 6], values: [{a: 2}, {a: 6}]},
 	{range: [6, 10], values: [{a: 7}, {a: 8}]},
@@ -373,8 +377,33 @@ export const getTrimmedBinsStats = bins => {
 export const getBinsTicks = _.pipe([
 	_.mapWith(_.getKey('range')),
 	_.flatten,
-	_.uniques
+	_.uniques,
+	_.sortWith([])
 ]);
+
+/**
+ * Return the extent of all ticks for the provided bins
+ *
+ * @function
+ * @arg {array} bins
+ * @return {number[]} ticks extent
+ *
+ * @example
+> getBinsTicksExtent([
+	{range: [-8, -3], values: []},
+	{range: [-3, 2], values: []},
+	{range: [2, 7], values: [2, 6, 7]},
+	{range: [7, 12], values: []},
+	{range: [12, 17], values: []},
+	{range: [17, 22], values: [18, 19, 20]},
+	{range: [22, 27], values: [24, 25]},
+	{range: [27, 32], values: []},
+])
+[-8, 32]
+ *
+ * @version 0.4.0
+ */
+export const getBinsTicksExtent = _.pipe([getBinsTicks, getFirstAndLast]);
 
 /**
  * Return the ticks for the provided bins using the non-empty ones

--- a/packages/components/histogram/src/utils.spec.js
+++ b/packages/components/histogram/src/utils.spec.js
@@ -12,9 +12,10 @@ import {
 	getBinsMax,
 	getBinsMin,
 	getBinsTicks,
-	isNonEmptyBin,
+	getBinsTicksExtent,
 	getNonEmptyBinsTicks,
-	getTrimmedBinsStats
+	getTrimmedBinsStats,
+	isNonEmptyBin,
 } from './utils';
 
 describe('histogram/utils', function() {
@@ -212,6 +213,24 @@ describe('histogram/utils', function() {
 			];
 			const actual = getBinsTicks(bins);
 			const expected = [-8, -3, 2, 7, 12, 17, 22, 27, 32];
+
+			assert.deepStrictEqual(actual, expected);
+		});
+	});
+	describe('getBinsTicksExtent', function() {
+		it('should return the extent of all ticks for the provided bins', function() {
+			const bins = [
+				{range: [-8, -3], values: []},
+				{range: [-3, 2], values: []},
+				{range: [2, 7], values: [2, 6, 7]},
+				{range: [7, 12], values: []},
+				{range: [12, 17], values: []},
+				{range: [17, 22], values: [18, 19, 20]},
+				{range: [22, 27], values: [24, 25]},
+				{range: [27, 32], values: []},
+			];
+			const actual = getBinsTicksExtent(bins);
+			const expected = [-8, 32];
 
 			assert.deepStrictEqual(actual, expected);
 		});

--- a/packages/components/legend/CHANGELOG.md
+++ b/packages/components/legend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `@svizzle/legend` v0.2.0 (next)
+
+- add the field `showTicksExtentOnly` to `flags` prop
+
 ## `@svizzle/legend` v0.1.2
 
 - updated some dev dependencies:

--- a/packages/components/time_region_value/src/routes/[id]/[year].svelte
+++ b/packages/components/time_region_value/src/routes/[id]/[year].svelte
@@ -117,7 +117,7 @@
 	$: legendHeight = height / 3;
 	$: choroplethSafety = {...defaultGeometry, left: legendBarThickness * 2};
 	$: id && year && hideInfoModal();
-	$: $selectedYearStore = Number(year);
+	$: selectedYearStore.set(Number(year));
 	$: getIndicatorFormat = makeGetIndicatorFormatOf(id);
 	$: formatFn = getIndicatorFormat($lookupStore);
 	$: getRefFormatFn = makeGetRefFormatOf(id);
@@ -155,7 +155,7 @@
 
 	// $: indicatorData = $lookupStore[id].data;
 	$: yearData = data && data.filter(obj => obj.year === year);
-	$: $availableYearsStore = availableYears;
+	$: availableYearsStore.set(availableYears);
 	$: makeKeyToValue = _.pipe([
 		_.indexBy(getNutsId),
 		_.mapValuesWith(getIndicatorValue)

--- a/packages/components/time_region_value/src/routes/[id]/index.svelte
+++ b/packages/components/time_region_value/src/routes/[id]/index.svelte
@@ -152,7 +152,7 @@
 	$: makeColorBins = $makeColorBinsStore;
 	$: getIndicatorFormat = makeGetIndicatorFormatOf(id);
 	$: formatFn = getIndicatorFormat($lookupStore);
-	$: $availableYearsStore = availableYears;
+	$: availableYearsStore.set(availableYears);
 	$: layout = $timelineLayoutStore;
 	$: getIndicatorValue = makeValueAccessor(id);
 	$: setOrder = makeSetOrderWith(getIndicatorValue);
@@ -332,6 +332,7 @@
 					value={'Absolute'}
 					values={['Absolute', 'Ranking']}
 					on:toggled={event => {
+						// eslint-disable-next-line no-unused-vars
 						useOrderScale = event.detail === 'Ranking'
 					}}
 				/>

--- a/packages/docs/site/CHANGELOG.md
+++ b/packages/docs/site/CHANGELOG.md
@@ -1,3 +1,9 @@
+## `@svizzle/site` v0.3.4 (next)
+
+- `legend/ColorsBinG`:
+   - document `flags.showTicksExtentOnly`
+   - document the `geometry` prop
+
 ## `@svizzle/site` v0.3.3
 
 - document `ExternalLink`

--- a/packages/docs/site/src/routes/components/_examples/legend.js
+++ b/packages/docs/site/src/routes/components/_examples/legend.js
@@ -102,6 +102,70 @@ export default formatExamples([
 		title: 'ColorBinsG: Basic props',
 	}, {
 		data: [{
+			key: 'default',
+			props: {
+				bins,
+			},
+			usage: `
+				<ColorBinsG
+					{bins}
+					{height}
+					{width}
+				/>
+			`,
+		}, {
+			key: 'Larger safety area',
+			props: {
+				bins,
+				geometry: {
+					left: 50,
+					top: 150,
+				}
+			},
+			usage: `
+				<ColorBinsG
+					{bins}
+					{height}
+					{width}
+					geometry: {{
+						left: 50,
+						top: 150,
+					}}
+				/>
+			`,
+		}, {
+			key: 'gap, barThickness, textPadding',
+			props: {
+				bins,
+				geometry: {
+					gap: 8,
+					barThickness: 50,
+					textPadding: 15,
+				}
+			},
+			usage: `
+				<ColorBinsG
+					{bins}
+					{height}
+					{width}
+					geometry: {{
+						gap: 8,
+						barThickness: 50,
+						textPadding: 15,
+					}}
+				/>
+			`,
+		}],
+		doc: [
+			{tag: 'p', content: 'Use the `geometry` prop to control safety areas (default: 10 px), bar thickness (default: 25 px), text padding (default: 5 px), gap (default: 2 px).'},
+		],
+		name: 'ColorBinsG',
+		namespace: 'svg',
+		packageName: 'legend',
+		slug: 'ColorBinsG-geometry',
+		title: 'ColorBinsG: geometry',
+	}, {
+		data: [{
 			key: 'horizontal',
 			props: {
 				bins,
@@ -140,6 +204,46 @@ export default formatExamples([
 		packageName: 'legend',
 		slug: 'ColorBinsG-orientation',
 		title: 'ColorBinsG: orientation',
+	}, {
+		data: [{
+			key: 'Show all ticks',
+			props: {
+				bins,
+			},
+			usage: `
+				<ColorBinsG
+					{bins}
+					{height}
+					{width}
+				/>
+			`,
+		}, {
+			key: 'Show ticks extent only',
+			props: {
+				bins,
+				flags: {
+					showTicksExtentOnly: true
+				}
+			},
+			usage: `
+				<ColorBinsG
+					{bins}
+					{height}
+					{width}
+					flags={{
+						showTicksExtentOnly: true
+					}}
+				/>
+			`,
+		}],
+		doc: [
+			{tag: 'p', content: 'To show just the ticks extent you can use the flag `showTicksExtentOnly`'},
+		],
+		name: 'ColorBinsG',
+		namespace: 'svg',
+		packageName: 'legend',
+		slug: 'ColorBinsG-ticks',
+		title: 'ColorBinsG: ticks',
 	}, {
 		data: [{
 			key: null,


### PR DESCRIPTION
Closes #218

Also:
- /histogram: add `getBinsTicksExtent` to utils
- /site: document `ColorBinsG`'s `geometry` prop
- fix linting