### PR TITLE
/ui: `A11yMenuDriver` now uses separate target selectors for font and color settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 	- fixed `sampleText` enlarging the document size
 	- renamed `ScreenGauge` to `ScreenSensor`
 	- made `ScreenSensor` into a singleton so that it renders only once
+	- removed `fontSize` property
 - add `StorageIO` component
 - add `A11yMenu` component
 

--- a/packages/components/ui/CHANGELOG.md
+++ b/packages/components/ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 	- fixed `sampleText` enlarging the document size
 	- renamed `ScreenGauge` to `ScreenSensor`
 	- made `ScreenSensor` into a singleton so that it renders only once
+	- removed `fontSize` property
 - add `StorageIO` component
 - add `A11yMenu` component
 

--- a/packages/components/ui/src/a11y/menu/A11yMenuDriver.svelte
+++ b/packages/components/ui/src/a11y/menu/A11yMenuDriver.svelte
@@ -10,17 +10,20 @@
 		mergeDefaultSettings,
 	} from './settings';
 
-	export let targetSelector = 'html';
+	const colorTargetSelector = 'html';
+	const textTargetSelector = 'body';
+
 	export let defaults = null;
 	export let useLocalStorage = true;
 
 	let defaultValue;
 
 	$: defaults && (defaultValue = mergeDefaultSettings(defaults));
-	$: targetNode = isClientSide && document.querySelector(targetSelector);
-	$: targetNode?.classList?.add(['color-corrected']);
-	$: targetNode && applyStyles(targetNode.style, $_a11yTextStyles);
-	$: targetNode && applyStyles(targetNode.style, $_a11yColorStyles);
+	$: colorTargetNode = isClientSide && document.querySelector(colorTargetSelector);
+	$: colorTargetNode?.classList?.add(['colorCorrected']);
+	$: colorTargetNode && applyStyles(colorTargetNode.style, $_a11yColorStyles);
+	$: textTargetNode = isClientSide && document.querySelector(textTargetSelector);
+	$: textTargetNode && applyStyles(textTargetNode.style, $_a11yTextStyles);
 </script>
 
 <ColorCorrection />

--- a/packages/components/ui/src/a11y/menu/ColorCorrection.svelte
+++ b/packages/components/ui/src/a11y/menu/ColorCorrection.svelte
@@ -70,7 +70,7 @@ https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html
 		position: fixed;
 		visibility: hidden;
 	}
-	:global(.color-corrected) {
+	:global(.colorCorrected) {
 		filter: var(--color-correction); /* color vision deficiency */
 	}
 	:global(.simulated-deuteranopia) {

--- a/packages/components/ui/src/a11y/menu/README.md
+++ b/packages/components/ui/src/a11y/menu/README.md
@@ -62,7 +62,6 @@ For a full implementation example please refer to
 Props:
 - `A11yMenuDriver`
 	- `defaults`: Will be merged with factory-default settings. See `settings.js`.
-	- `targetSelector`: Effects will bind to the first element selected by this. Default value is `'html'`.
 	- `useLocalStorage`: When true, settings are stored in browser's local storage and loaded on landing.
 - `A11yMenu`
 	- `_screen`: Receives the `_screen` store from `<ScreenSensor/>`.

--- a/packages/components/ui/src/sensors/screen/ScreenSensor.svelte
+++ b/packages/components/ui/src/sensors/screen/ScreenSensor.svelte
@@ -26,7 +26,6 @@
 	const instanceId = instancesCount++;
 	const shouldRender = instanceId === 0;
 
-	export let fontSize = null;
 	export let isDev = false;
 	export let sampleText = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 	export let breakpoints = defaultBreakpoints;
@@ -92,7 +91,6 @@
 
 	$: isServerSide = typeof window === 'undefined';
 	$: sampleHeight && sampleWidth && updateScreen();
-	$: fontSize && updateScreen();
 	$: devInfo = shouldRender && $_screen && {
 		Classes: $_screen.classes,
 		Display: `${$_screen.display.width} x ${$_screen.display.height} px`,
@@ -113,7 +111,6 @@
 		<span
 			bind:offsetWidth={sampleWidth}
 			bind:offsetHeight={sampleHeight}
-			style={fontSize && `font-size: ${fontSize}`}
 		>{sampleText}</span>
 	</div>
 

--- a/packages/docs/site/static/global.css
+++ b/packages/docs/site/static/global.css
@@ -59,6 +59,7 @@ html {
 	the background must be set to a color.
 	*/
 	background-color: white;
+	font-size: 14px;
 }
 
 body {


### PR DESCRIPTION
Closes #390