### PR TITLE
/ui: replaced bound size variables by `ResizeObserver` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 	- renamed `ScreenGauge` to `ScreenSensor`
 	- made `ScreenSensor` into a singleton so that it renders only once
 	- removed `fontSize` property
+	- replaced bound size variables by `ResizeObserver` action
 - add `StorageIO` component
 - add `A11yMenu` component
 - add `FontsLoader` component

--- a/packages/components/ui/CHANGELOG.md
+++ b/packages/components/ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 	- renamed `ScreenGauge` to `ScreenSensor`
 	- made `ScreenSensor` into a singleton so that it renders only once
 	- removed `fontSize` property
+	- replaced bound size variables by `ResizeObserver` action
 - add `StorageIO` component
 - add `A11yMenu` component
 - add `FontsLoader` component

--- a/packages/components/ui/src/actions/README.md
+++ b/packages/components/ui/src/actions/README.md
@@ -1,0 +1,32 @@
+# Svelte actions
+
+## resizeObserver
+
+This action can track an element's dimensions more reliably than Svelte's
+`innerHeight`/`innerWidth` binding mechanisms which sometimes fail due to
+unfixed bugs and implementation differences in browsers and operating systems.
+
+### Usage
+
+```svelte
+<script>
+	import {setupResizeObserver} from '../../actions/resizeObserver';
+   	const {_writable: _elementSize, resizeObserver} = setupResizeObserver();
+
+	$: console.log($_elementSize);
+</script>
+
+<p use:resizeObserver>
+    Some text content.
+</p>
+```
+
+The action can also receive a configuration string with values `borderBoxSize`
+or `contentBoxSize` to specify which dimensions to retrieve. The default value
+is `borderBoxSize`.
+
+```svelte
+<p use:resizeObserver='contentBoxSize'>
+    Some text content.
+</p>
+```

--- a/packages/components/ui/src/actions/README.md
+++ b/packages/components/ui/src/actions/README.md
@@ -17,7 +17,7 @@ unfixed bugs and implementation differences in browsers and operating systems.
 </script>
 
 <p use:resizeObserver>
-    Some text content.
+	Some text content.
 </p>
 ```
 
@@ -27,6 +27,6 @@ is `borderBoxSize`.
 
 ```svelte
 <p use:resizeObserver='contentBoxSize'>
-    Some text content.
+	Some text content.
 </p>
 ```

--- a/packages/components/ui/src/actions/resizeObserver.js
+++ b/packages/components/ui/src/actions/resizeObserver.js
@@ -1,0 +1,14 @@
+import {writable} from 'svelte/store';
+
+export const setupResizeObserver = () => {
+	const _writable = writable({blockSize: 0, inlineSize: 0});
+
+	function resizeObserver (node, type = 'borderBoxSize') {
+		const callback = entries => _writable.set(entries[0][type][0]);
+		const observer = new ResizeObserver(callback);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}
+
+	return {_writable, resizeObserver}
+}

--- a/packages/components/ui/src/sensors/screen/WindowBinder.svelte
+++ b/packages/components/ui/src/sensors/screen/WindowBinder.svelte
@@ -1,6 +1,6 @@
 <script>
-	export let innerHeight;
-	export let innerWidth;
+	export let innerHeight = null;
+	export let innerWidth = null;
 	export let onResize;
 </script>
 


### PR DESCRIPTION
Closes #396

Also:
- defined properties in `WindowBinder` to eliminate runtime warnings