### PR TITLE
/ui: cleaned up some code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - add `A11yMenu` component
 - add `FontsLoader` component
 - replaced some absolute CSS definitions related to text and fonts
+- added missing components to `rollup` input variable
+- fixed linting errors in `src/a11y/menu/settings.js`
 
 ## `@svizzle/atlas` v0.6.0 (next)
 

--- a/packages/components/ui/CHANGELOG.md
+++ b/packages/components/ui/CHANGELOG.md
@@ -15,6 +15,8 @@
 - add `A11yMenu` component
 - add `FontsLoader` component
 - replaced some absolute CSS definitions related to text and fonts
+- added missing components to `rollup` input variable
+- fixed linting errors in `src/a11y/menu/settings.js`
 
 ## `@svizzle/ui` v0.4.0
 

--- a/packages/components/ui/rollup.config.js
+++ b/packages/components/ui/rollup.config.js
@@ -24,13 +24,20 @@ const dir = 'dist';
 const external = pkg.peerDependencies && Object.keys(pkg.peerDependencies) || [];
 
 const input = {
+	A11yMenu: 'src/a11y/menu/A11yMenu.svelte',
+	A11yMenuDriver: 'src/a11y/menu/A11yMenuDriver.svelte',
+	FontsLoader: 'src/drivers/fonts/FontsLoader.svelte',
 	Icon: 'src/icons/Icon.svelte',
 	index: 'src/index.js',
 	Link: 'src/Link.svelte',
 	LinkButton: 'src/LinkButton.svelte',
 	LoadingView: 'src/LoadingView.svelte',
 	MessageView: 'src/MessageView.svelte',
+	MultiBanner: 'src/MultiBanner.svelte',
+	NoScript: 'src/NoScript.svelte',
+	ResponsiveFlex: 'src/ResponsiveFlex.svelte',
 	ScreenSensor: 'src/sensors/screen/ScreenSensor.svelte',
+	StorageIO: 'src/io/storage/StorageIO.svelte',
 	Switch: 'src/Switch.svelte',
 };
 const removeComments = cleanup({

--- a/packages/components/ui/src/Link.svelte
+++ b/packages/components/ui/src/Link.svelte
@@ -51,7 +51,7 @@
 	class:underlined={isUnderlined}
 >
 	<span class:bold={isBold}>
-		<slot></slot>
+		<slot/>
 	</span>
 	{#if isExternal && showIcon}
 		<span>

--- a/packages/components/ui/src/a11y/menu/settings.js
+++ b/packages/components/ui/src/a11y/menu/settings.js
@@ -199,8 +199,8 @@ export const updateCurrentValue = value => {
 const setValueToDefault = makeMergeAppliedFnMap({value: _.getKey('defaultValue')});
 
 const isValidValue = setting => value =>
-	(setting.values && value in setting.values)
-	|| (setting.range && isValueInRange(value, setting.range))
+	setting.values && value in setting.values
+	|| setting.range && isValueInRange(value, setting.range)
 
 const mergeOnlyUpdateValueIfInvalid = (newSetting, oldSetting) => {
 	const setting = isValidValue(newSetting)(oldSetting.value)
@@ -210,9 +210,11 @@ const mergeOnlyUpdateValueIfInvalid = (newSetting, oldSetting) => {
 }
 
 export const mergeDefaultSettings = newDefaultSettings => {
-	newDefaultSettings = _.mapValuesWith(setValueToDefault)(newDefaultSettings);
+	const mergedDefaultSettings = _.mapValuesWith(setValueToDefault)(
+		newDefaultSettings
+	);
 	_a11ySettings.update(
-		_.curry(mergeWith(mergeOnlyUpdateValueIfInvalid))(newDefaultSettings)
+		_.curry(mergeWith(mergeOnlyUpdateValueIfInvalid))(mergedDefaultSettings)
 	);
 	return mergeWithMerge(defaultA11ySettings, newDefaultSettings);
 }
@@ -225,10 +227,10 @@ const getGroupsResetStatus = _.pipe([
 	_.mapValuesWith(
 		_.pipe([
 			_.mapWith(
-					_.collect([
-						_.getKey('value'),
-						_.getKey('defaultValue'),
-					])
+				_.collect([
+					_.getKey('value'),
+					_.getKey('defaultValue'),
+				])
 			),
 			_.every(_.apply(_.areSame))
 		])
@@ -249,7 +251,9 @@ const resetGroupItems = groupId => _.mapValuesWith(_.adapter([
 	_.casus(isNotOfGroup(groupId), _.identity),
 	_.casus(_.hasKey('value'), setValueToDefault),
 ]));
-export const resetGroup = groupId => _a11ySettings.update(resetGroupItems(groupId));
+export const resetGroup = groupId => _a11ySettings.update(
+	resetGroupItems(groupId)
+);
 
 /* Color corrections CSS property formatter */
 const getValuesOrderedByKeys = keys => obj => _.map(keys, key => obj[key]);

--- a/packages/docs/site/src/routes/_layout.svelte
+++ b/packages/docs/site/src/routes/_layout.svelte
@@ -51,7 +51,7 @@
 </header>
 
 <main>
-	<slot></slot>
+	<slot/>
 </main>
 {#if showA11yMenu}
 	<section

--- a/packages/docs/site/src/routes/components/_layout.svelte
+++ b/packages/docs/site/src/routes/components/_layout.svelte
@@ -25,7 +25,7 @@
 		{/each}
 	</nav>
 	<main>
-		<slot></slot>
+		<slot/>
 	</main>
 </section>
 


### PR DESCRIPTION
Closes #395

Details:
- formatting: <slot></slot> => <slot />
- added missing components to `rollup` input variable
- fixed linting errors in `src/a11y/menu/settings.js`