### PR TITLE
Various fixes for the ESM release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Svizzle changelog
 
+## next
+
+## `@svizzle/barchart` v0.8.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
+## `@svizzle/choropleth` v0.9.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
+## `@svizzle/histogram` v0.6.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
+## `@svizzle/legend` v0.4.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
+## `@svizzle/time_region_value` v0.8.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
+## `@svizzle/ui` v0.7.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+- removed `FetchDriver` from `src/index.js` to avoid build issues
+
+## `@svizzle/request` v0.5.1
+
+- rearranged `rxjs` imports to minimize impact during import
+- moved `rxjs` out of `devDependencies`
+
 ## 20220912
 
 - upgrade to ESM:

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
 				"sapper": "^0.29.3",
 				"serve-handler": "^6.1.3",
 				"sirv": "^2.0.2",
-				"svelte": "^3.38.3",
+				"svelte": "^3.50.1",
 				"svelte-json-tree": "^1.0.0",
 				"svg-parser": "^2.0.4",
 				"tempy": "^3.0.0",

--- a/packages/components/barchart/CHANGELOG.md
+++ b/packages/components/barchart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `@svizzle/barchart` v0.8.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
 ## `@svizzle/barchart` v0.8.0
 
 - upgrade to ESM:

--- a/packages/components/barchart/package.json
+++ b/packages/components/barchart/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"eslint": "^8.23.0",
 		"eslint-plugin-svelte3": "^4.0.0",
-		"svelte": "^3.38.3"
+		"svelte": "^3.50.1"
 	},
 	"engines": {
 		"node": ">=17.5.0"

--- a/packages/components/barchart/package.json
+++ b/packages/components/barchart/package.json
@@ -61,6 +61,7 @@
 		"unlink": "npm unlink -g"
 	},
 	"sideEffects": false,
+	"svelte": "src/index.js",
 	"type": "module",
 	"version": "0.8.0"
 }

--- a/packages/components/choropleth/CHANGELOG.md
+++ b/packages/components/choropleth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `@svizzle/choropleth` v0.9.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
 ## `@svizzle/choropleth` v0.9.0
 
 - upgrade to ESM:

--- a/packages/components/choropleth/package.json
+++ b/packages/components/choropleth/package.json
@@ -61,6 +61,7 @@
 		"unlink": "npm unlink -g"
 	},
 	"sideEffects": false,
+	"svelte": "src/index.js",
 	"type": "module",
 	"version": "0.9.0"
 }

--- a/packages/components/choropleth/package.json
+++ b/packages/components/choropleth/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"eslint": "^8.23.0",
 		"eslint-plugin-svelte3": "^4.0.0",
-		"svelte": "^3.38.3"
+		"svelte": "^3.50.1"
 	},
 	"engines": {
 		"node": ">=17.5.0"

--- a/packages/components/histogram/CHANGELOG.md
+++ b/packages/components/histogram/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `@svizzle/histogram` v0.6.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
 ## `@svizzle/histogram` v0.6.0
 
 - upgrade to ESM:

--- a/packages/components/histogram/package.json
+++ b/packages/components/histogram/package.json
@@ -20,7 +20,7 @@
 		"eslint": "^8.23.0",
 		"eslint-plugin-svelte3": "^4.0.0",
 		"mocha": "^8.3.2",
-		"svelte": "^3.38.3"
+		"svelte": "^3.50.1"
 	},
 	"engines": {
 		"node": ">=17.5.0"

--- a/packages/components/histogram/package.json
+++ b/packages/components/histogram/package.json
@@ -65,6 +65,7 @@
 		"unlink": "npm unlink -g"
 	},
 	"sideEffects": false,
+	"svelte": "src/index.js",
 	"type": "module",
 	"version": "0.6.0"
 }

--- a/packages/components/legend/CHANGELOG.md
+++ b/packages/components/legend/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `@svizzle/legend` v0.4.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
 ## `@svizzle/legend` v0.4.0
 
 - upgrade to ESM:

--- a/packages/components/legend/package.json
+++ b/packages/components/legend/package.json
@@ -64,6 +64,7 @@
 		"unlink": "npm unlink -g"
 	},
 	"sideEffects": false,
+	"svelte": "src/index.js",
 	"type": "module",
 	"version": "0.4.0"
 }

--- a/packages/components/legend/package.json
+++ b/packages/components/legend/package.json
@@ -19,7 +19,7 @@
 	"devDependencies": {
 		"eslint": "^8.23.0",
 		"eslint-plugin-svelte3": "^4.0.0",
-		"svelte": "^3.38.3"
+		"svelte": "^3.50.1"
 	},
 	"engines": {
 		"node": ">=17.5.0"

--- a/packages/components/time_region_value/CHANGELOG.md
+++ b/packages/components/time_region_value/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `@svizzle/time_region_value` v0.8.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
 ## `@svizzle/time_region_value` v0.8.0
 
 - upgrade to ESM:

--- a/packages/components/time_region_value/package.json
+++ b/packages/components/time_region_value/package.json
@@ -77,6 +77,7 @@
 		"unlink": "npm unlink -g"
 	},
 	"sideEffects": false,
+	"svelte": "src/index.js",
 	"type": "module",
 	"version": "0.8.0"
 }

--- a/packages/components/time_region_value/package.json
+++ b/packages/components/time_region_value/package.json
@@ -32,7 +32,7 @@
 	"devDependencies": {
 		"eslint": "^8.23.0",
 		"eslint-plugin-svelte3": "^4.0.0",
-		"svelte": "^3.38.3"
+		"svelte": "^3.50.1"
 	},
 	"engines": {
 		"node": ">=17.5.0"

--- a/packages/components/ui/CHANGELOG.md
+++ b/packages/components/ui/CHANGELOG.md
@@ -1,3 +1,9 @@
+## `@svizzle/ui` v0.7.1 (next)
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+- removed `FetchDriver` from `src/index.js` to avoid build issues
+
 ## `@svizzle/ui` v0.7.0
 
 - upgrade to ESM:

--- a/packages/components/ui/package.json
+++ b/packages/components/ui/package.json
@@ -27,7 +27,7 @@
 		"lamb": "^0.60.0",
 		"mkdirp": "^1.0.4",
 		"rimraf": "^3.0.2",
-		"svelte": "^3.38.3",
+		"svelte": "^3.50.1",
 		"svg-parser": "^2.0.4"
 	},
 	"engines": {
@@ -70,6 +70,7 @@
 		"unlink": "npm unlink -g"
 	},
 	"sideEffects": false,
+	"svelte": "src/index.js",
 	"type": "module",
 	"version": "0.7.0"
 }

--- a/packages/components/ui/src/index.js
+++ b/packages/components/ui/src/index.js
@@ -2,7 +2,7 @@ export * from './a11y/index.js';
 export * from './actions/resizeObserver.js';
 export * from './drivers/fonts/index.js';
 export * from './icons/index.js';
-export {default as FetchDriver} from './io/net/FetchDriver.svelte';
+// export {default as FetchDriver} from './io/net/FetchDriver.svelte';
 export {default as StorageIO} from './io/storage/StorageIO.svelte';
 export * from './sensors/index.js';
 export * from './utils/env.js';

--- a/packages/docs/site/package.json
+++ b/packages/docs/site/package.json
@@ -44,7 +44,7 @@
 		"rollup-plugin-terser": "^7.0.2",
 		"sapper": "^0.29.3",
 		"sirv": "^2.0.2",
-		"svelte": "^3.38.3"
+		"svelte": "^3.50.1"
 	},
 	"engines": {
 		"node": ">=17.5.0"

--- a/packages/tools/request/CHANGELOG.md
+++ b/packages/tools/request/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `@svizzle/request` v0.5.1
+
+- rearranged `rxjs` imports to minimize impact during import
+- moved `rxjs` out of `devDependencies`
+
 ## `@svizzle/request` v0.5.0
 
 - upgrade to ESM:

--- a/packages/tools/request/package.json
+++ b/packages/tools/request/package.json
@@ -10,7 +10,8 @@
 	"dependencies": {
 		"@svizzle/utils": "^0.18.0",
 		"d3-fetch": "^3.0.1",
-		"lamb": "^0.60.0"
+		"lamb": "^0.60.0",
+		"rxjs": "^7.5.6"
 	},
 	"description": "Svizzle Request contains helpers for fetching data.",
 	"devDependencies": {
@@ -19,7 +20,6 @@
 		"mocha": "^8.3.2",
 		"nock": "^13.2.9",
 		"node-fetch": "^3.1.0",
-		"rxjs": "^7.5.6",
 		"serve-handler": "^6.1.3",
 		"throttle": "^1.0.3",
 		"undici": "4.12.2"

--- a/packages/tools/request/src/fetchManager/fetchManager.js
+++ b/packages/tools/request/src/fetchManager/fetchManager.js
@@ -6,10 +6,10 @@ import * as _ from 'lamb';
 import {
 	BehaviorSubject,
 	from,
-	Subject,
-	zipWith
+	Subject
 } from 'rxjs';
 import {
+	zipWith,
 	debounceTime,
 	filter,
 	map,

--- a/packages/tools/request/src/fetchManager/rxUtils.js
+++ b/packages/tools/request/src/fetchManager/rxUtils.js
@@ -1,5 +1,4 @@
-import {combineLatestWith} from 'rxjs';
-import {map, debounceTime, share} from 'rxjs/operators';
+import {combineLatestWith, debounceTime, map, share} from 'rxjs/operators';
 
 export const derive = ([first, ...rest], fn) =>
 	first.pipe(


### PR DESCRIPTION
closes #554

Also:
- ui: commented out `FetchDriver` component
- request:
  - rearranged `rxjs` imports to minimize impact during import
  - moved `rxjs` out of `devDependencies`