### PR TITLE
Release 20220913

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,33 @@
 # Svizzle changelog
 
-## next
+## 20220913
 
-## `@svizzle/barchart` v0.8.1 (next)
-
-- upgraded `svelte`
-- added `"svelte": "src/index.js"` field to `package.json`
-
-## `@svizzle/choropleth` v0.9.1 (next)
+## `@svizzle/barchart` v0.8.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`
 
-## `@svizzle/histogram` v0.6.1 (next)
+## `@svizzle/choropleth` v0.9.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`
 
-## `@svizzle/legend` v0.4.1 (next)
+## `@svizzle/histogram` v0.6.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`
 
-## `@svizzle/time_region_value` v0.8.1 (next)
+## `@svizzle/legend` v0.4.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`
 
-## `@svizzle/ui` v0.7.1 (next)
+## `@svizzle/time_region_value` v0.8.1
+
+- upgraded `svelte`
+- added `"svelte": "src/index.js"` field to `package.json`
+
+## `@svizzle/ui` v0.7.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`

--- a/packages/components/barchart/CHANGELOG.md
+++ b/packages/components/barchart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## `@svizzle/barchart` v0.8.1 (next)
+## `@svizzle/barchart` v0.8.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`

--- a/packages/components/barchart/package.json
+++ b/packages/components/barchart/package.json
@@ -63,5 +63,5 @@
 	"sideEffects": false,
 	"svelte": "src/index.js",
 	"type": "module",
-	"version": "0.8.0"
+	"version": "0.8.1"
 }

--- a/packages/components/choropleth/CHANGELOG.md
+++ b/packages/components/choropleth/CHANGELOG.md
@@ -1,4 +1,4 @@
-## `@svizzle/choropleth` v0.9.1 (next)
+## `@svizzle/choropleth` v0.9.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`

--- a/packages/components/choropleth/package.json
+++ b/packages/components/choropleth/package.json
@@ -63,5 +63,5 @@
 	"sideEffects": false,
 	"svelte": "src/index.js",
 	"type": "module",
-	"version": "0.9.0"
+	"version": "0.9.1"
 }

--- a/packages/components/histogram/CHANGELOG.md
+++ b/packages/components/histogram/CHANGELOG.md
@@ -1,4 +1,4 @@
-## `@svizzle/histogram` v0.6.1 (next)
+## `@svizzle/histogram` v0.6.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`

--- a/packages/components/histogram/package.json
+++ b/packages/components/histogram/package.json
@@ -67,5 +67,5 @@
 	"sideEffects": false,
 	"svelte": "src/index.js",
 	"type": "module",
-	"version": "0.6.0"
+	"version": "0.6.1"
 }

--- a/packages/components/legend/CHANGELOG.md
+++ b/packages/components/legend/CHANGELOG.md
@@ -1,4 +1,4 @@
-## `@svizzle/legend` v0.4.1 (next)
+## `@svizzle/legend` v0.4.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`

--- a/packages/components/legend/package.json
+++ b/packages/components/legend/package.json
@@ -10,7 +10,7 @@
 	"dependencies": {
 		"@svizzle/dom": "^0.7.0",
 		"@svizzle/geometry": "^0.5.0",
-		"@svizzle/histogram": "^0.6.0",
+		"@svizzle/histogram": "^0.6.1",
 		"@svizzle/utils": "^0.18.0",
 		"lamb": "^0.60.0",
 		"yootils": "^0.3.1"
@@ -66,5 +66,5 @@
 	"sideEffects": false,
 	"svelte": "src/index.js",
 	"type": "module",
-	"version": "0.4.0"
+	"version": "0.4.1"
 }

--- a/packages/components/time_region_value/CHANGELOG.md
+++ b/packages/components/time_region_value/CHANGELOG.md
@@ -1,4 +1,4 @@
-## `@svizzle/time_region_value` v0.8.1 (next)
+## `@svizzle/time_region_value` v0.8.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`

--- a/packages/components/time_region_value/package.json
+++ b/packages/components/time_region_value/package.json
@@ -9,12 +9,12 @@
 	},
 	"dependencies": {
 		"@svizzle/atlas": "^0.8.0",
-		"@svizzle/barchart": "^0.8.0",
-		"@svizzle/choropleth": "^0.9.0",
+		"@svizzle/barchart": "^0.8.1",
+		"@svizzle/choropleth": "^0.9.1",
 		"@svizzle/dom": "^0.7.0",
 		"@svizzle/geo": "^0.9.0",
-		"@svizzle/legend": "^0.4.0",
-		"@svizzle/ui": "^0.7.0",
+		"@svizzle/legend": "^0.4.1",
+		"@svizzle/ui": "^0.7.1",
 		"@svizzle/utils": "^0.18.0",
 		"d3-array": "^3.2.0",
 		"d3-dsv": "^3.0.1",
@@ -79,5 +79,5 @@
 	"sideEffects": false,
 	"svelte": "src/index.js",
 	"type": "module",
-	"version": "0.8.0"
+	"version": "0.8.1"
 }

--- a/packages/components/ui/CHANGELOG.md
+++ b/packages/components/ui/CHANGELOG.md
@@ -1,4 +1,4 @@
-## `@svizzle/ui` v0.7.1 (next)
+## `@svizzle/ui` v0.7.1
 
 - upgraded `svelte`
 - added `"svelte": "src/index.js"` field to `package.json`

--- a/packages/components/ui/package.json
+++ b/packages/components/ui/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"@svizzle/dev": "^0.6.0",
 		"@svizzle/file": "^0.14.0",
-		"@svizzle/request": "^0.5.0",
+		"@svizzle/request": "^0.5.1",
 		"camelcase": "^7.0.0",
 		"eslint": "^8.23.0",
 		"eslint-plugin-svelte3": "^4.0.0",
@@ -72,5 +72,5 @@
 	"sideEffects": false,
 	"svelte": "src/index.js",
 	"type": "module",
-	"version": "0.7.0"
+	"version": "0.7.1"
 }

--- a/packages/docs/site/package.json
+++ b/packages/docs/site/package.json
@@ -2,13 +2,13 @@
 	"description": "Svizzle documentation site",
 	"dependencies": {
 		"@svizzle/atlas": "^0.8.0",
-		"@svizzle/barchart": "^0.8.0",
-		"@svizzle/choropleth": "^0.9.0",
+		"@svizzle/barchart": "^0.8.1",
+		"@svizzle/choropleth": "^0.9.1",
 		"@svizzle/geo": "^0.9.0",
-		"@svizzle/histogram": "^0.6.0",
-		"@svizzle/legend": "^0.4.0",
-		"@svizzle/time_region_value": "^0.8.0",
-		"@svizzle/ui": "^0.7.0",
+		"@svizzle/histogram": "^0.6.1",
+		"@svizzle/legend": "^0.4.1",
+		"@svizzle/time_region_value": "^0.8.1",
+		"@svizzle/ui": "^0.7.1",
 		"@svizzle/utils": "^0.18.0",
 		"d3-color": "^3.1.0",
 		"d3-geo": "^3.0.1",
@@ -66,5 +66,5 @@
 		"TODO_test": "run-p --race dev cy:run"
 	},
 	"type": "module",
-	"version": "0.4.0"
+	"version": "0.4.1"
 }

--- a/packages/tools/request/package.json
+++ b/packages/tools/request/package.json
@@ -64,5 +64,5 @@
 	},
 	"sideEffects": true,
 	"type": "module",
-	"version": "0.5.0"
+	"version": "0.5.1"
 }


### PR DESCRIPTION
closes #556

Changes:
 - @svizzle/barchart: 0.8.0 => 0.8.1
 - @svizzle/choropleth: 0.9.0 => 0.9.1
 - @svizzle/histogram: 0.6.0 => 0.6.1
 - @svizzle/legend: 0.4.0 => 0.4.1
 - @svizzle/time_region_value: 0.8.0 => 0.8.1
 - @svizzle/ui: 0.7.0 => 0.7.1
 - @svizzle/site: 0.4.0 => 0.4.1 (private)
 - @svizzle/request: 0.5.0 => 0.5.1