### PR TITLE
/ui: fixed `StyleDriver` export in `index.js`

### DIFF
--- a/packages/components/ui/src/index.js
+++ b/packages/components/ui/src/index.js
@@ -1,7 +1,7 @@
 export * from './a11y/index.js';
 export * from './actions/resizeObserver.js';
 export * from './drivers/fonts/index.js';
-export * from './drivers/style/StyleDriver.svelte';
+export {default as StyleDriver} from './drivers/style/StyleDriver.svelte';
 export * from './icons/index.js';
 // export {default as FetchDriver} from './io/net/FetchDriver.svelte';
 export {default as StorageIO} from './io/storage/StorageIO.svelte';


### PR DESCRIPTION
closes #601