### PR TITLE
/ui: Upgraded `Link` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - added `CopyToClipboard.svelte`
 - added `ScrollbarStyler.svelte`
 - added `PLATFORM` and `isPlatformIn(oses, browsers)`
+- `Link`:
+	- spacebar scrolling disabled when focused
+	- added `outlineColor`, `outlineStyle` and `outlineWidth` theme props
+	- added `ariaDescribedBy` and `ariaLabel` props
 
 ## `@svizzle/site` v0.4.1 (next)
 

--- a/packages/components/ui/CHANGELOG.md
+++ b/packages/components/ui/CHANGELOG.md
@@ -7,6 +7,10 @@
 - added `CopyToClipboard.svelte`
 - added `ScrollbarStyler.svelte`
 - added `PLATFORM` and `isPlatformIn(oses, browsers)`
+- `Link`:
+	- spacebar scrolling disabled when focused
+	- added `outlineColor`, `outlineStyle` and `outlineWidth` theme props
+	- added `ariaDescribedBy` and `ariaLabel` props
 
 ## `@svizzle/ui` v0.8.0
 

--- a/packages/components/ui/src/Link.svelte
+++ b/packages/components/ui/src/Link.svelte
@@ -30,7 +30,6 @@
 	export let type = null;
 
 	const disableSpaceToScroll = e => {
-		console.log(e)
 		if (e.keyCode === 32) {
 			e.preventDefault()
 		}
@@ -50,7 +49,6 @@
 
 	$: isExternal = type === 'external';
 	$: theme = theme ? {...defaultTheme, ...theme} : defaultTheme;
-	// $: style = theme.color ? `--color: ${theme.color}` : null;
 	$: style = makeStyleVars(theme);
 </script>
 

--- a/packages/components/ui/src/Link.svelte
+++ b/packages/components/ui/src/Link.svelte
@@ -1,7 +1,8 @@
 <script>
 	import {makeStyleVars} from '@svizzle/dom';
-	import {ExternalLink, Icon} from './icons/index';
-	import {defaultRel} from './utils/shared';
+
+	import {ExternalLink, Icon} from './icons/index.js';
+	import {defaultRel} from './utils/shared.js';
 
 	const defaultIconSize = 14;
 	const {defaultStrokeWidth} = Icon;

--- a/packages/components/ui/src/Link.svelte
+++ b/packages/components/ui/src/Link.svelte
@@ -1,16 +1,21 @@
 <script>
-	import ExternalLink from './icons/feather/ExternalLink.svelte';
-	import Icon from './icons/Icon.svelte';
-	import {defaultRel} from './utils/shared.js';
+	import {makeStyleVars} from '@svizzle/dom';
+	import {ExternalLink, Icon} from './icons/index';
+	import {defaultRel} from './utils/shared';
 
 	const defaultIconSize = 14;
 	const {defaultStrokeWidth} = Icon;
 	const defaultTheme = {
+		color: 'black',
 		iconStroke: 'rgb(16, 174, 249)',
 		iconStrokeWidth: defaultStrokeWidth,
-		color: 'black',
+		outlineColor: 'black',
+		outlineStyle: 'solid',
+		outlineWidth: '1px',
 	};
 
+	export let ariaDescribedBy = null;
+	export let ariaLabel = null;
 	export let download = null;
 	export let href = null;
 	export let hreflang = null;
@@ -22,6 +27,13 @@
 	export let target = null;
 	export let theme = null;
 	export let type = null;
+
+	const disableSpaceToScroll = e => {
+		console.log(e)
+		if (e.keyCode === 32) {
+			e.preventDefault()
+		}
+	}
 
 	// FIXME https://github.com/sveltejs/svelte/issues/4442
 	$: download = download || null;
@@ -37,10 +49,13 @@
 
 	$: isExternal = type === 'external';
 	$: theme = theme ? {...defaultTheme, ...theme} : defaultTheme;
-	$: style = theme.color ? `--color: ${theme.color}` : null;
+	// $: style = theme.color ? `--color: ${theme.color}` : null;
+	$: style = makeStyleVars(theme);
 </script>
 
 <a
+	aria-describedby={ariaDescribedBy}
+	aria-label={ariaLabel}
 	download={download ? '' : null}
 	{href}
 	{hreflang}
@@ -49,6 +64,7 @@
 	{target}
 	{type}
 	class:underlined={isUnderlined}
+	on:keydown={disableSpaceToScroll}
 >
 	<span class:bold={isBold}>
 		<slot/>
@@ -78,6 +94,11 @@
 	}
 	a span:nth-child(2) {
 		margin-left: 0.1rem;
+	}
+
+	a:focus-visible {
+		outline: var(--outlineWidth) var(--outlineStyle) var(--outlineColor);
+		outline-offset: calc(-1 * var(--outlineWidth));
 	}
 
 	.bold {

--- a/packages/docs/site/src/routes/components/_examples/ui/Link.js
+++ b/packages/docs/site/src/routes/components/_examples/ui/Link.js
@@ -91,7 +91,7 @@ export const data = [
 		`,
 	},
 	{
-		content: 'Svelte website',
+		content: 'Focus me to see the outline style',
 		key: 'Style',
 		props: {
 			href: 'https://svelte.dev',
@@ -99,6 +99,9 @@ export const data = [
 				color: 'orange',
 				iconStroke: 'red',
 				iconStrokeWidth: 4,
+				outlineColor: 'blue',
+				outlineStyle: 'dotted',
+				outlineWidth: '2px',
 			},
 			type: 'external'
 		},
@@ -109,10 +112,13 @@ export const data = [
 					color: 'orange',
 					iconStroke: 'red',
 					iconStrokeWidth: 4,
+					outlineColor: 'blue',
+					outlineStyle: 'dotted',
+					outlineWidth: '2px',
 				}}
 				type='external'
 			>
-				Svelte website
+				Focus me to see the outline style
 			</Link>
 		`,
 	},


### PR DESCRIPTION
closes #609

Details:
- spacebar scrolling disabled when focused
- added `focusOutline` and `focusOutlineOffset` theme props
- added `ariaDescribedBy` and `ariaLabel` props