### PR TITLE
/utils: average functions return zero when passed empty arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,8 +125,8 @@
 - added `isRegexpEmpty`, `isRegexpNotEmpty`
 - added `makeRegexOf`, `makeSafeRegexOf`
 - added `regexOf`, `safeRegexOf`
+- changed: `arrayAverage`, `keyValueArrayAverage`, `makeAverageWith` return zero when passed empty arrays
 - updated license year
-
 
 ## 20221003
 

--- a/packages/tools/utils/CHANGELOG.md
+++ b/packages/tools/utils/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added `isRegexpEmpty`, `isRegexpNotEmpty`
 - added `makeRegexOf`, `makeSafeRegexOf`
 - added `regexOf`, `safeRegexOf`
+- changed: `arrayAverage`, `keyValueArrayAverage`, `makeAverageWith` return zero when passed empty arrays
 - updated license year
 
 ## `@svizzle/utils` v0.18.0

--- a/packages/tools/utils/src/modules/[any-number]-[array-number].js
+++ b/packages/tools/utils/src/modules/[any-number]-[array-number].js
@@ -80,8 +80,11 @@ export const arrayMinWith = fn => _.reduceWith((min, item) => {
 3
 > sumValues([{a: 'hey'}, {notA: 'b'}, {notA: 3}])
 0
+> sumValues([])
+0
  *
  * @since 0.16.0
+ * @see {@link module:@svizzle/utils/array-number.arraySum|arraySum}
  */
 export const arraySumWith = accessor => _.reduceWith((acc, item) => {
 	const value = accessor(item);
@@ -103,16 +106,13 @@ export const arraySumWith = accessor => _.reduceWith((acc, item) => {
 	{a: 10, b: 7},
 	{a: 7, b: 9},
 ])
-> makeAverageOfA([
-	{a: 11, b: 4},
-	{a: 7, b: 9},
-	{a: 9, b: 0},
-])
-9
+6
+> makeAverageOfA([])
+0
  *
  * @since 0.11.0
  */
 export const makeAverageWith = accessor => _.pipe([
 	_.collect([arraySumWith(accessor), getLength]),
-	_.apply(_.divide),
+	([sum, length]) => length ? sum / length : 0
 ]);

--- a/packages/tools/utils/src/modules/[any-number]-[array-number].spec.js
+++ b/packages/tools/utils/src/modules/[any-number]-[array-number].spec.js
@@ -64,10 +64,14 @@ describe('(Any -> Number) -> (Array -> Number)', function () {
 				{notA: 3},
 			]), 0);
 		});
+		it('should return zero when passed an empty array', function () {
+			assert.deepStrictEqual(sumValues([]), 0);
+		});
 	});
 	describe('makeAverageWith', function () {
+		const makeAverageOfA = makeAverageWith(_.getKey('a'));
+
 		it('should return a function expecting an array of objects and returning the max of results of applying the provided fuction on all of the array items', function () {
-			const makeAverageOfA = makeAverageWith(_.getKey('a'));
 
 			assert.deepStrictEqual(makeAverageOfA([
 				{a: 1, b: 2},
@@ -79,6 +83,9 @@ describe('(Any -> Number) -> (Array -> Number)', function () {
 				{a: 7, b: 9},
 				{a: 9, b: 0},
 			]), 9);
-		})
+		});
+		it('should return zero when passed an empty array', function () {
+			assert.deepStrictEqual(makeAverageOfA([]), 0);
+		});
 	})
 })

--- a/packages/tools/utils/src/modules/array-number.js
+++ b/packages/tools/utils/src/modules/array-number.js
@@ -74,6 +74,7 @@ export const arrayMin = _.apply(Math.min);
 0
  *
  * @since 0.3.0
+ * @see {@link module:@svizzle/utils/[any-number]-[array-number].arraySumWith|arraySumWith}
  */
 export const arraySum = _.reduceWith(_.sum, 0);
 
@@ -87,12 +88,14 @@ export const arraySum = _.reduceWith(_.sum, 0);
  * @example
 > arrayAverage([1, 23, 6])
 10
+> arrayAverage([])
+0
  *
  * @since 0.11.0
  */
 export const arrayAverage = _.pipe([
 	_.collect([arraySum, getLength]),
-	_.apply(_.divide),
+	([sum, length]) => length ? sum / length : 0
 ]);
 
 /**
@@ -109,10 +112,12 @@ export const arrayAverage = _.pipe([
 	{key: 'c', value: 6},
 ])
 10
+> keyValueArrayAverage([])
+0
  *
  * @since 0.11.0
  */
 export const keyValueArrayAverage = _.pipe([
 	_.collect([arraySumWith(getValue), getLength]),
-	_.apply(_.divide),
+	([sum, length]) => length ? sum / length : 0
 ]);

--- a/packages/tools/utils/src/modules/array-number.spec.js
+++ b/packages/tools/utils/src/modules/array-number.spec.js
@@ -42,6 +42,9 @@ describe('Array -> Number', function () {
 		it('should return the average of the numbers in the provided array', function () {
 			assert.deepStrictEqual(arrayAverage([1, 23, 6]), 10);
 		});
+		it('should return zero when passed an empty array', function () {
+			assert.deepStrictEqual(arrayAverage([]), 0);
+		});
 	});
 	describe('keyValueArrayAverage', function () {
 		it('should return the average of values of a {key, value}[] array', function () {
@@ -50,6 +53,9 @@ describe('Array -> Number', function () {
 				{key: 'b', value: 23},
 				{key: 'c', value: 6},
 			]), 10);
+		});
+		it('should return zero when passed an empty array', function () {
+			assert.deepStrictEqual(keyValueArrayAverage([]), 0);
 		});
 	});
 


### PR DESCRIPTION
fixes #632