### PR TITLE
/ui: use correct css var names for `ResponsiveButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Svizzle changelog
 
+## next
+
+## `@svizzle/ui` v0.9.1 (next)
+
+- use correct css var names in `ResponsiveButton`
+
+
 ## 20230111
 
 Notes for changelogs below:

--- a/packages/components/ui/CHANGELOG.md
+++ b/packages/components/ui/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `@svizzle/ui` v0.9.1 (next)
+
+- use correct css var names in `ResponsiveButton`
+
 ## `@svizzle/ui` v0.9.0
 
 - added `AlphabetPicker.svelte`

--- a/packages/components/ui/src/ResponsiveButton.svelte
+++ b/packages/components/ui/src/ResponsiveButton.svelte
@@ -91,8 +91,8 @@
 		justify-content: center;
 	}
 	.active {
-		background: var(--colorActiveBackground);
-		color: var(--colorActiveText);
+		background: var(--colorBackgroundActive);
+		color: var(--colorTextActive);
 	}
 
 	.ResponsiveButtonSensor {


### PR DESCRIPTION
fixes #653