### PR TITLE
Release 20230518

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Svizzle changelog
 
-## next
+## 20230518
 
-## `@svizzle/barchart` v0.10.0 (next)
+## `@svizzle/barchart` v0.10.0
 
 - added `valueToColorFn` prop
 
-## `@svizzle/site` v0.4.5 (next)
+## `@svizzle/time_region_value` v0.9.2
+
+- updated deps
+
+## `@svizzle/site` v0.4.5
 
 - /barchart: added doc for the `valueToColorFn` prop
 

--- a/packages/components/barchart/CHANGELOG.md
+++ b/packages/components/barchart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## `@svizzle/barchart` v0.10.0 (next)
+## `@svizzle/barchart` v0.10.0
 
 - added `valueToColorFn` prop
 

--- a/packages/components/barchart/package.json
+++ b/packages/components/barchart/package.json
@@ -64,5 +64,5 @@
 	"sideEffects": false,
 	"svelte": "src/index.js",
 	"type": "module",
-	"version": "0.9.0"
+	"version": "0.10.0"
 }

--- a/packages/components/time_region_value/CHANGELOG.md
+++ b/packages/components/time_region_value/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `@svizzle/time_region_value` v0.9.2
+
+- updated deps
+
 ## `@svizzle/time_region_value` v0.9.1
 
 - updated deps

--- a/packages/components/time_region_value/package.json
+++ b/packages/components/time_region_value/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"@svizzle/atlas": "^0.9.0",
-		"@svizzle/barchart": "^0.9.0",
+		"@svizzle/barchart": "^0.10.0",
 		"@svizzle/choropleth": "^0.9.2",
 		"@svizzle/dom": "^0.7.1",
 		"@svizzle/geo": "^0.9.1",
@@ -81,5 +81,5 @@
 	"sideEffects": false,
 	"svelte": "src/index.js",
 	"type": "module",
-	"version": "0.9.1"
+	"version": "0.9.2"
 }

--- a/packages/docs/site/CHANGELOG.md
+++ b/packages/docs/site/CHANGELOG.md
@@ -1,4 +1,4 @@
-## `@svizzle/site` v0.4.5 (next)
+## `@svizzle/site` v0.4.5
 
 - /barchart: added doc for the `valueToColorFn` prop
 

--- a/packages/docs/site/package.json
+++ b/packages/docs/site/package.json
@@ -2,14 +2,14 @@
 	"description": "Svizzle documentation site",
 	"dependencies": {
 		"@svizzle/atlas": "^0.9.0",
-		"@svizzle/barchart": "^0.9.0",
+		"@svizzle/barchart": "^0.10.0",
 		"@svizzle/choropleth": "^0.9.2",
 		"@svizzle/dom": "^0.7.1",
 		"@svizzle/geo": "^0.9.1",
 		"@svizzle/histogram": "^0.6.3",
 		"@svizzle/legend": "^0.4.3",
 		"@svizzle/mapbox": "^0.1.0",
-		"@svizzle/time_region_value": "^0.9.1",
+		"@svizzle/time_region_value": "^0.9.2",
 		"@svizzle/ui": "^0.9.1",
 		"@svizzle/utils": "^0.19.0",
 		"d3-color": "^3.1.0",
@@ -70,5 +70,5 @@
 		"TODO_test": "run-p --race dev cy:run"
 	},
 	"type": "module",
-	"version": "0.4.4"
+	"version": "0.4.5"
 }


### PR DESCRIPTION
closes #670

Changes:
 - @svizzle/barchart: 0.9.0 => 0.10.0
 - @svizzle/time_region_value: 0.9.1 => 0.9.2
 - @svizzle/site: 0.4.4 => 0.4.5 (private)