### PR TITLE
/ui: `ScreenSensor`, fixed the measured `glyph.height` being too big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 - updated bar chart event handlers to adapt to the changes in `@svizzle/barchart` v0.11.0
 
+## `@svizzle/ui` v0.10.1 (next)
+
+- `ScreenSensor`: fixed the measured `glyph.height` being too big
+
 ## `@svizzle/site` v0.4.6 (next)
 
 - /barchart: added doc for the `geometry` prop

--- a/packages/components/ui/CHANGELOG.md
+++ b/packages/components/ui/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `@svizzle/ui` v0.10.1 (next)
+
+- `ScreenSensor`: fixed the measured `glyph.height` being too big
+
+
 ## `@svizzle/ui` v0.10.0
 
 - added `resizeHandler` action

--- a/packages/components/ui/src/Scroller.svelte
+++ b/packages/components/ui/src/Scroller.svelte
@@ -65,7 +65,6 @@
 		height: 100%;
 		overflow: auto;
 		position: relative;
-		z-index: 1;
 	}
 
 	.shadowTop {

--- a/packages/components/ui/src/sensors/screen/ScreenSensor.svelte
+++ b/packages/components/ui/src/sensors/screen/ScreenSensor.svelte
@@ -127,8 +127,10 @@
 
 <style>
 	.textSample {
-		background: blue;
+		background: palegreen;
+		font-size: 1rem;
 		left: 0;
+		line-height: 1rem;
 		overflow: hidden;
 		pointer-events: none;
 		position: fixed;


### PR DESCRIPTION
fixes #705