### PR TITLE
/utils: `makeTrimmedSplitBy` now also trims before splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,11 @@
 ## `@svizzle/utils` v0.21.0 (next)
 
 - added `areEqual`, `areEqualWith`, `areValuesEqual`, `areValuesEqualWith`
+- added `pluckKey`, `pluckValue`
+- added `pairToKeyValuesObject`, `objectToKeyValuesArray`
 - upgraded `just-compare`, `lamb`, `mocha`, `eslint`
+- `makeTrimmedSplitBy` now also trims before splitting
+
 
 ## 20231114
 

--- a/packages/tools/utils/CHANGELOG.md
+++ b/packages/tools/utils/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added `pluckKey`, `pluckValue`
 - added `pairToKeyValuesObject`, `objectToKeyValuesArray`
 - upgraded `just-compare`, `lamb`, `mocha`, `eslint`
+- `makeTrimmedSplitBy` now also trims before splitting
 
 ## `@svizzle/utils` v0.20.0
 

--- a/packages/tools/utils/src/modules/string-[string-array].js
+++ b/packages/tools/utils/src/modules/string-[string-array].js
@@ -66,6 +66,7 @@ export const makeSplitBy = _.curryRight(split, 2);
  * @since 0.19.0
  */
 export const makeTrimmedSplitBy = separator => _.pipe([
+	trim,
 	_.splitBy(separator),
 	_.mapWith(trim)
 ]);


### PR DESCRIPTION
closes #739
