### PR TITLE
add exports field in package.json

### DIFF
--- a/packages/components/mapbox/package.json
+++ b/packages/components/mapbox/package.json
@@ -60,6 +60,11 @@
 	},
 	"sideEffects": false,
 	"svelte": "src/index.js",
+	"exports": {
+		".": {
+			"svelte": "./src/index.js"
+		}
+	},
 	"type": "module",
 	"version": "0.2.0"
 }


### PR DESCRIPTION
Hi, thanks for your awesome list of tools. I have been recently using your mapbox wrapper with svelte-kit (TypeScript) and I have noticed the following error in my terminal when running my app.

```
[vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

@svizzle/mapbox@0.2.0

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```

Following the above link, Vite suggests adding the `exports` field I have included in my commit. After doing that, the functionality of the library remains the same but the console error also goes away. You might probably need to do that for the rest of your libraries too. Thanks!